### PR TITLE
make sure the PGTStorage object is initialized if a user is utilizing the createTable method

### DIFF
--- a/source/CAS/PGTStorage/Db.php
+++ b/source/CAS/PGTStorage/Db.php
@@ -274,6 +274,11 @@ class CAS_PGTStorage_Db extends CAS_PGTStorage_AbstractStorage
 	{
 		phpCAS::traceBegin();
 
+		// initialize this PGTStorage object if it hasn't been initialized yet
+		if ( !$this->isInitialized() ) {
+			$this->init();
+		}
+
 		// initialize the PDO object for this method
 		$pdo = $this->getPdo();
 		$this->setErrorMode();


### PR DESCRIPTION
This is a minor ease of use fix if someone is utilizing the createTable method on the CAS_PGTStorage_Db object.

the createTable method isn't part of the standard phpCAS PGTStorage API, so the cas client may not have initialized this object before the user attempts to use createTable. This will guarantee that the object is initialized before executing the createTable SQL
