### PR TITLE
Fix include_path order so that the phpCAS path takes precedence.

### DIFF
--- a/source/CAS/Autoload.php
+++ b/source/CAS/Autoload.php
@@ -63,7 +63,7 @@ foreach ($____paths as $____path) {
     }
 }
 if (!$____found) {
-    set_include_path(get_include_path() . PATH_SEPARATOR . dirname(dirname(__FILE__)));
+    set_include_path(dirname(dirname(__FILE__)) . PATH_SEPARATOR . get_include_path());
 }
 unset($____paths);
 unset($____path);


### PR DESCRIPTION
This allows a newer version of phpCAS to be used, even if an old version is already in the include_path.

This seems to work fine, but I just wanted to check with the rest of you before merging into master in case this might cause other issues.
