### PR TITLE
init() should set _initialized to true

### DIFF
--- a/source/CAS/PGTStorage/AbstractStorage.php
+++ b/source/CAS/PGTStorage/AbstractStorage.php
@@ -175,7 +175,7 @@ abstract class CAS_PGTStorage_AbstractStorage
      */
     function init()
     {
-        $this->_initialized = false;
+        $this->_initialized = true;
     }
 
     // ########################################################################


### PR DESCRIPTION
This bug was introduced in e77378cc259adb68e7c77b19eab1e974da85a2d6
