### PR TITLE
Remove erroneous break statement

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1703,7 +1703,6 @@ class CAS_Client
         $arr = preg_split('/\n/', $text_response);
         $this->_setUser(trim($arr[1]));
         $result = true;
-        break;
 
         if ($result) {
             $this->_renameSession($this->getTicket());


### PR DESCRIPTION
With this statement in place, a fatal error is thrown during
a CAS 1.0 authentication attempt.
