### PR TITLE
Use of X-Forwarded-Port

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3089,11 +3089,17 @@ class CAS_Client
             }
         }
         if (!strpos($server_url, ':')) {
-            if ( ($this->_isHttps() && $_SERVER['SERVER_PORT']!=443)
-                || (!$this->_isHttps() && $_SERVER['SERVER_PORT']!=80)
+            if (empty($_SERVER['HTTP_X_FORWARDED_PORT'])) {
+                $server_port = $_SERVER['SERVER_PORT'];
+            } else {
+                $server_port = $_SERVER['HTTP_X_FORWARDED_PORT'];
+            }
+
+            if ( ($this->_isHttps() && $server_port!=443)
+                || (!$this->_isHttps() && $server_port!=80)
             ) {
                 $server_url .= ':';
-                $server_url .= $_SERVER['SERVER_PORT'];
+                $server_url .= $server_port;
             }
         }
         return $server_url;


### PR DESCRIPTION
We're using phpCAS along with wpcas-w-ldap, a Wordpress plugin for CAS/LDAP based authentication. In our cluster and reverse proxy setup, the web application server isn't listening on ports 80/443, but the front-end proxy does. We set X-Forwarded-Server and X-Forwarded-Port, so we need phpCAS to honour them both in the URL it gives to CAS.
Cheers
