### PR TITLE
Wrong value set for CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/source/CAS/Request/CurlRequest.php
+++ b/source/CAS/Request/CurlRequest.php
@@ -117,12 +117,12 @@ implements CAS_Request_RequestInterface
          * Set SSL configuration
         *********************************************************/
         if ($this->caCertPath) {
-            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 1);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
             curl_setopt($ch, CURLOPT_CAINFO, $this->caCertPath);
             phpCAS::trace('CURL: Set CURLOPT_CAINFO');
         } else {
-            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 1);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
         }
 


### PR DESCRIPTION
CURLOPT_SSL_VERIFYHOST should be set to 2 not to 1.

From the libcurl documentation:

> When CURLOPT_SSL_VERIFYHOST is 2, that certificate must indicate that the
> server is the server to which you meant to connect, or the connection fails.
> 
> Curl considers the server the intended one when the Common Name field or a
> Subject Alternate Name field in the certificate matches the host name in the
> URL to which you told Curl to connect.
> 
> When the value is 1, the certificate must contain a Common Name field, but it
> doesn't matter what name it says. (This is not ordinarily a useful setting).

Thanks for ghedo from debian.org for reporting.
