### PR TITLE
Commit/Write&Close session before flush()

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1353,6 +1353,7 @@ class CAS_Client
                 if ($this->_clearTicketsFromUrl) {
                     phpCAS::trace("Prepare redirect to : ".$this->getURL());
                     header('Location: '.$this->getURL());
+                    session_write_close();
                     flush();
                     phpCAS::traceExit();
                     throw new CAS_GracefullTerminationException();
@@ -1460,6 +1461,7 @@ class CAS_Client
                 if ($this->_clearTicketsFromUrl) {
                     phpCAS::trace("Prepare redirect to : ".$this->getURL());
                     header('Location: '.$this->getURL());
+                    session_write_close();
                     flush();
                     phpCAS::traceExit();
                     throw new CAS_GracefullTerminationException();


### PR DESCRIPTION
I have different session save handler to meet the needs of the greatest number.
One of this session save handler stores session inside crypted cookie(s). The main advantage to store session in cookie is for architecture-less shared session between multi fontends.
But in order to work, session save handler must be able to write and close session at the end of the script execution by sending cookie headers.

However if you send a `flush();` just after the header cannot be modified afterward.

Can simply reproduce with this sort of code:

```
header('Location: index.php?test');
flush();
header("Set-Cookie: thecookie=thevalue", false);
```

You will see that cookie does not appear on the new page. 
Nevertheless this one work

```
header('Location: index.php?test');
header("Set-Cookie: thecookie=thevalue", false);
```

Thus if we add `session_write_close();` before `flush();` that force handler to "write&close" session manually.
And the flow will look like:

```
header('Location: index.php?test');
session_write_close(); // => header("Set-Cookie: thecookie=thevalue", false);
flush();
```

---

`session_commit();` is an alias for `session_write_close();` that why I'm talking about commit inside title.
