### PR TITLE
Add support for X-Forwarded-Proto header in isHttps()

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3503,6 +3503,9 @@ class CAS_Client
      */
     private function _isHttps()
     {
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            return ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
+        }
         if ( isset($_SERVER['HTTPS'])
             && !empty($_SERVER['HTTPS'])
             && $_SERVER['HTTPS'] == 'on'


### PR DESCRIPTION
We have phpCAS running on a web server that is behind a reverse proxy.  Clients connect to the reverse proxy using HTTPS, but the reverse proxy connects to the web server using plain HTTP.  An X-Forwarded-Proto header (containing either 'http' or 'https') is added by the reverse proxy to notify the application on the web server whether the client connection used HTTP or HTTPS.

isHttps() in phpCAS currently returns 'false' in this situation. This patch updates phpCAS so that it uses the X-Forwarded-Proto header if it is available.

Thanks!
