### PR TITLE
Adding "autoload" section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "gorg/phpcas",
+    "type": "php-lib",
+    "description": "An library for use CAS Authentication",
+    "keywords": ["gorg", "cas", "jasig"],
+    "license": "GPL",
+    "authors": [
+        {
+            "name": "Mathieu GOULIN",
+            "email": "mathieu.goulin@gadz.org"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2"
+    },
+    "minimum-stability": "dev",
+    "target-dir": "/",
+    "extra": {
+    }
+}


### PR DESCRIPTION
Hi,
Sorry if i pull request the wrong way, i'm new too GitHub!
It would be usefull to add this to your composer.json in order to avoid "require_once **VENDOR_DIR** . '/gorg/phpcas/CAS.php' (or such things) in our application :

```
"autoload": {
    "files": [
        "CAS.php"
    ]
}
```

Regards,
Bertrand
