### PR TITLE
Clear session data before writing the session

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1639,12 +1639,12 @@ class CAS_Client
             $cas_url = $cas_url . $paramSeparator . "service="
                 . urlencode($params['service']);
         }
+        session_unset();
+        session_destroy();
         session_write_close();
         header('Location: '.$cas_url);
         phpCAS::trace("Prepare redirect to : ".$cas_url);
 
-        session_unset();
-        session_destroy();
         $lang = $this->getLangObj();
         $this->printHTMLHeader($lang->getLogout());
         printf('<p>'.$lang->getShouldHaveBeenRedirected(). '</p>', $cas_url);


### PR DESCRIPTION
Session is written and then cleared, which leaves the session full
with all it's data. We need to clean the session and then write.
