### PR TITLE
_isHTTPS : add control on X-Forwarded-Proto = https

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3293,9 +3293,12 @@ class CAS_Client
      */
     private function _isHttps()
     {
-        if ( isset($_SERVER['HTTPS'])
+        if ( (isset($_SERVER['HTTPS'])
             && !empty($_SERVER['HTTPS'])
-            && $_SERVER['HTTPS'] == 'on'
+            && $_SERVER['HTTPS'] == 'on')
+            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+            && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https') 
+    
         ) {
             return true;
         } else {


### PR DESCRIPTION
In a situation where the PHP application sits behind a reverse proxy or load balancer ssl offloading, we need to check the X-Forwarded-Proto HTTP header set by the frontend.
