### PR TITLE
Ampersands being double-encoded, causing service not to validate

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3227,7 +3227,7 @@ class CAS_Client
             $final_uri .= '://';
 
             $final_uri .= $this->_getServerUrl();
-            $request_uri	= explode('?', $_SERVER['REQUEST_URI'], 2);
+            $request_uri	= explode('?', html_entity_decode($_SERVER['REQUEST_URI']), 2);
             $final_uri		.= $request_uri[0];
 
             if (isset($request_uri[1]) && $request_uri[1]) {


### PR DESCRIPTION
## Description Of Problem:

In CAS_Client::getURL(), the url parameters are obtained via `$_SERVER['REQUEST_URI']` which gives ampersands in the html form: &amp;

This is then passed to urlencode() in CAS_Client::getServerLoginURL(), which encodes the ampersand as %26amp%3B.

These two facts cause the service url to be malformed in the following ways:
- The ticket number is not properly removed from the URL in CAS_Client::getURL(), because the regex to replace it looks specifically for &ticket, not &amp;ticket.
- If there are multiple parameters, they also have &amp; (and, in the end %26amp%3B), causing the services not to match the service of the ticket. That, in turn, causes an authentication exception.
## Proposed Fix:

Calling html_entity_decode() on `$_SERVER['REQUEST_URI']` in phpCAS::getURL() resolves the problem, and it doesn't seem to create any new ones, as far as I can tell, since it would still be passed to urlencode() before use, anyway, and if the problem doesn't exist on a particular system, the call to html_entity_decode() would not do anything.
## Versions Affected:

I have tested this on ubuntu server and centos 6, both of which are affected by this bug. Both have the latest pear install of this code: version 1.3.2.
## Relevant Logs:

NOTE: I added backslashes to the logs so that it would display properly here on github. They are not there in the original log. Initial redirect is in the 4D07 section, error occurs when checking the url in the C350 section.
4D07 .START phpCAS-1.3.2 *****************\* [CAS.php:450]
4D07 .=> phpCAS::client('2.0', 'cas-test.ucdavis.edu', 443, 'cas') [index.php:53]
4D07 .|    => CAS_Client::__construct('2.0', false, 'cas-test.ucdavis.edu', 443, 'cas', true) [CAS.php:347]
4D07 .|    |    Starting a new session [Client.php:792]
4D07 .|    <= ''
4D07 .<= ''
4D07 .=> phpCAS::setNoCasServerValidation() [index.php:58]
4D07 .|    You have configured no validation of the legitimacy of the cas server. This is not recommended for production use. [CAS.php:1669]
4D07 .<= ''
4D07 .=> phpCAS::forceAuthentication() [customer.php:19]
4D07 .|    => CAS_Client::forceAuthentication() [CAS.php:1101]
4D07 .|    |    => CAS_Client::isAuthenticated() [Client.php:1083]
4D07 .|    |    |    => CAS_Client::_wasPreviouslyAuthenticated() [Client.php:1189]
4D07 .|    |    |    |    no user found [Client.php:1375]
4D07 .|    |    |    <= false
4D07 .|    |    |    no ticket found [Client.php:1258]
4D07 .|    |    <= false
4D07 .|    |    => CAS_Client::redirectToCas(false) [Client.php:1092]
4D07 .|    |    |    => CAS_Client::getServerLoginURL(false, false) [Client.php:1396]
4D07 .|    |    |    |    => CAS_Client::getURL() [Client.php:328]
4D07 .|    |    |    |    |    Final URI: http://localhost/index.php?route=checkout/cart [Client.php:3071]
4D07 .|    |    |    |    <= 'http://localhost/index.php?route=checkout/cart'
4D07 .|    |    |    <= 'https://cas-test.ucdavis.edu/cas/login?service=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3Dcheckout%2Fcart'
4D07 .|    |    |    Redirect to : https://cas-test.ucdavis.edu/cas/login?service=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3Dcheckout%2Fcart [Client.php:1402]
4D07 .|    |    |    exit()
4D07 .|    |    |    -
4D07 .|    |    -
4D07 .|    -
C350 .START phpCAS-1.3.2 *****************\* [CAS.php:450]
C350 .=> phpCAS::client('2.0', 'cas-test.ucdavis.edu', 443, 'cas') [index.php:53]
C350 .|    => CAS_Client::__construct('2.0', false, 'cas-test.ucdavis.edu', 443, 'cas', true) [CAS.php:347]
C350 .|    |    Starting a new session [Client.php:792]
C350 .|    |    Ticket 'ST-1061-LOeHa6Yppge2z6g1gceP-fred' found [Client.php:870]
C350 .|    <= ''
C350 .<= ''
C350 .=> phpCAS::setNoCasServerValidation() [index.php:58]
C350 .|    You have configured no validation of the legitimacy of the cas server. This is not recommended for production use. [CAS.php:1669]
C350 .<= ''
C350 .=> phpCAS::forceAuthentication() [customer.php:19]
C350 .|    => CAS_Client::forceAuthentication() [CAS.php:1101]
C350 .|    |    => CAS_Client::isAuthenticated() [Client.php:1083]
C350 .|    |    |    => CAS_Client::_wasPreviouslyAuthenticated() [Client.php:1189]
C350 .|    |    |    |    no user found [Client.php:1375]
C350 .|    |    |    <= false
C350 .|    |    |    CAS 2.0 ticket `ST-1061-LOeHa6Yppge2z6g1gceP-fred' is present [Client.php:1223]
C350 .|    |    |    => CAS_Client::validateCAS20('', NULL, NULL) [Client.php:1224]
C350 .|    |    |    |     [Client.php:2747]
C350 .|    |    |    |    => CAS_Client::getServerServiceValidateURL() [Client.php:2753]
C350 .|    |    |    |    |    => CAS_Client::getURL() [Client.php:417]
C350 .|    |    |    |    |    |    Final URI: http://localhost/index.php?route=checkout/cart&amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred [Client.php:3071]
C350 .|    |    |    |    |    <= 'http://localhost/index.php?route=checkout/cart&amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred'
C350 .|    |    |    |    <= 'https://cas-test.ucdavis.edu/cas/serviceValidate?service=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3Dcheckout%2Fcart%26amp%3Bticket%3DST-1061-LOeHa6Yppge2z6g1gceP-fred'
C350 .|    |    |    |    => CAS_Client::_readURL('https://cas-test.ucdavis.edu/cas/serviceValidate?service=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3Dcheckout%2Fcart%26amp%3Bticket%3DST-1061-LOeHa6Yppge2z6g1gceP-fred&ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred', NULL, NULL, NULL) [Client.php:2762]
C350 .|    |    |    |    |    => CAS_Request_CurlRequest::sendRequest() [AbstractRequest.php:220]
C350 .|    |    |    |    |    |    Response Body: 
C350 .|    |    |    |    |    |  
C350 .|    |    |    |    |    |  
C350 .|    |    |    |    |    |  
C350 .|    |    |    |    |    |    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
C350 .|    |    |    |    |    |        <cas:authenticationFailure code='INVALID_SERVICE'>
C350 .|    |    |    |    |    |            ticket &#039;ST-1061-LOeHa6Yppge2z6g1gceP-fred&#039; does not match supplied service.  The original service was &#039;http://localhost/index.php?route=checkout/cart&#039; and the supplied service was &#039;http://localhost/index.php?route=checkout/cart&amp;amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred&#039;.
C350 .|    |    |    |    |    |        /cas:authenticationFailure
C350 .|    |    |    |    |    |    /cas:serviceResponse
C350 .|    |    |    |    |    |     [CurlRequest.php:82]
C350 .|    |    |    |    |    <= true
C350 .|    |    |    |    <= true
C350 .|    |    |    |    => CAS_AuthenticationException::__construct(CAS_Client, 'Ticket not validated', 'https://cas-test.ucdavis.edu/cas/serviceValidate?service=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3Dcheckout%2Fcart%26amp%3Bticket%3DST-1061-LOeHa6Yppge2z6g1gceP-fred&ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred', false, false, '<cas:serviceResponse xmlns:cas=\'http://www.yale.edu/tp/cas\'>    <cas:authenticationFailure code=\'INVALID_SERVICE\'>        ticket &#039;ST-1061-LOeHa6Yppge2z6g1gceP-fred&#039; does not match supplied service.  The original service was &#039;http://localhost/index.php?route=checkout/cart&#039; and the supplied service was &#039;http://localhost/index.php?route=checkout/car\t&amp;amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred&#039;.   /cas:authenticationFailure/cas:serviceResponse', 'INVALID_SERVICE', 'ticket \'ST-1061-LOeHa6Yppge2z6g1gceP-fred\' does not match supplied service.  The original service was \'http://localhost/index.php?route=checkout/cart\' and the supplied service was \'http://localhost/index.php?route=checkout/cart&amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred\'.') [Client.php:2845]
C350 .|    |    |    |    |    => CAS_Client::getURL() [AuthenticationException.php:76]
C350 .|    |    |    |    |    <= 'http://localhost/index.php?route=checkout/cart&amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred'
C350 .|    |    |    |    |    CAS URL: https://cas-test.ucdavis.edu/cas/serviceValidate?service=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3Dcheckout%2Fcart%26amp%3Bticket%3DST-1061-LOeHa6Yppge2z6g1gceP-fred&ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred [AuthenticationException.php:79]
C350 .|    |    |    |    |    Authentication failure: Ticket not validated [AuthenticationException.php:80]
C350 .|    |    |    |    |    Reason: [INVALID_SERVICE] CAS error: ticket 'ST-1061-LOeHa6Yppge2z6g1gceP-fred' does not match supplied service.  The original service was 'http://localhost/index.php?route=checkout/cart' and the supplied service was 'http://localhost/index.php?route=checkout/cart&amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred'. [AuthenticationException.php:95]
C350 .|    |    |    |    |    CAS response: 
C350 .|    |    |    |    |  
C350 .|    |    |    |    |  
C350 .|    |    |    |    |    <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
C350 .|    |    |    |    |     <cas:authenticationFailure code='INVALID_SERVICE'>
C350 .|    |    |    |    |         ticket &#039;ST-1061-LOeHa6Yppge2z6g1gceP-fred&#039; does not match supplied service.  The original service was &#039;http://localhost/index.php?route=checkout/cart&#039; and the supplied service was &#039;http://localhost/index.php?route=checkout/cart&amp;amp;ticket=ST-1061-LOeHa6Yppge2z6g1gceP-fred&#039;.
C350 .|    |    |    |    |     /cas:authenticationFailure
C350 .|    |    |    |    |    /cas:serviceResponse [AuthenticationException.php:100]
C350 .|    |    |    |    |    exit()
C350 .|    |    |    |    |    -
C350 .|    |    |    |    -
C350 .|    |    |    -
C350 .|    |    - .|    -
