### PR TITLE
Fix for missing intermediate variables introduced by #101

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3472,7 +3472,8 @@ class CAS_Client
         $server_url = '';
         if (!empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
             // explode the host list separated by comma and use the first host
-            $server_url = reset(explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']));
+            $hosts = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);
+            $server_url = $hosts[0];
         } else if (!empty($_SERVER['HTTP_X_FORWARDED_SERVER'])) {
             $server_url = $_SERVER['HTTP_X_FORWARDED_SERVER'];
         } else {
@@ -3486,7 +3487,8 @@ class CAS_Client
             if (empty($_SERVER['HTTP_X_FORWARDED_PORT'])) {
                 $server_port = $_SERVER['SERVER_PORT'];
             } else {
-                $server_port = reset(explode(',', $_SERVER['HTTP_X_FORWARDED_PORT']));
+                $ports = explode(',', $_SERVER['HTTP_X_FORWARDED_PORT']);
+                $server_port = $ports[0];
             }
 
             if ( ($this->_isHttps() && $server_port!=443)


### PR DESCRIPTION
This preserves the behavioral change introduced in #101, but adds intermediate
variables to avoid PHP "strict standards" errors.

Partially reverts 4e0157f2c7d2c00e294c9b28b0b71da712c44893
