### PR TITLE
Test if session is active before destroying it

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1644,7 +1644,9 @@ class CAS_Client
         phpCAS::trace("Prepare redirect to : ".$cas_url);
 
         session_unset();
-        session_destroy();
+        if (session_status() == PHP_SESSION_ACTIVE) {
+	    session_destroy();
+        }
         $lang = $this->getLangObj();
         $this->printHTMLHeader($lang->getLogout());
         printf('<p>'.$lang->getShouldHaveBeenRedirected(). '</p>', $cas_url);


### PR DESCRIPTION
This test prevent warning "session_destroy(): Trying to destroy uninitialized session"
