### PR TITLE
Parse error when exception is triggered

### DIFF
--- a/source/CAS/OutOfSequenceBeforeProxyException.php
+++ b/source/CAS/OutOfSequenceBeforeProxyException.php
@@ -53,7 +53,7 @@ implements CAS_Exception
     public function __construct ()
     {
         parent::__construct(
-            'this method cannot be called before phpCAS::proxy()''
+            'this method cannot be called before phpCAS::proxy()'
         );
     }
 }


### PR DESCRIPTION
Fixes PHP Parse error:  syntax error, unexpected T_ENCAPSED_AND_WHITESPACE in CAS/CAS/OutOfSequenceBeforeProxyException.php on line 5
