### PR TITLE
alias dev-master to 1.3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
         "classmap": [
             "source/"
         ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.3.x-dev"
+        }
     }
-
 }


### PR DESCRIPTION
I think that's what it really is for the moment: the next 1.3.x
(development version). Aliasing this branch to 1.3.x-dev allows people
to install dev-master but keep a real version constraint (like ~1.3) and
be confident they're not going to get BC-breaks.
