### PR TITLE
Update AuthenticationException.php

### DIFF
--- a/source/CAS/AuthenticationException.php
+++ b/source/CAS/AuthenticationException.php
@@ -74,7 +74,7 @@ implements CAS_Exception
         printf(
             $lang->getYouWereNotAuthenticated(),
             htmlentities($client->getURL()),
-            $_SERVER['SERVER_ADMIN']
+            isset($_SERVER['SERVER_ADMIN']) ? $_SERVER['SERVER_ADMIN']:''
         );
         phpCAS::trace('CAS URL: '.$cas_url);
         phpCAS::trace('Authentication failure: '.$failure);


### PR DESCRIPTION
`$_SERVER['SERVER_ADMIN']` might not always be set, especially if you are using nginx, instead of apache.

This produces a notice: 

``` text
PHP Notice: Undefined index: SERVER_ADMIN in \CAS\AuthenticationException.php on line 77
```

I added the following logic, 

``` php
if( isset($_SERVER['SERVER_ADMIN']) )
    return $_SERVER['SERVER_ADMIN'];
else
    return '';
```

This is how I simplified it:

``` php
isset($_SERVER['SERVER_ADMIN']) ? $_SERVER['SERVER_ADMIN']:''
```
