### PR TITLE
Fix bug on https test

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3513,7 +3513,7 @@ class CAS_Client
         }
         if ( isset($_SERVER['HTTPS'])
             && !empty($_SERVER['HTTPS'])
-            && $_SERVER['HTTPS'] == 'on'
+            && $_SERVER['HTTPS'] != 'off'
         ) {
             return true;
         } else {


### PR DESCRIPTION
According to [php.net](http://www.php.net/manual/en/reserved.variables.server.php). The request is HTTPS if `$_SERVER['HTTPS']` is not empty and different to `'off'`
