### PR TITLE
Refactor session handling

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -322,12 +322,13 @@ class phpCAS
     /**
      * phpCAS client initializer.
      *
-     * @param string $server_version  the version of the CAS server
-     * @param string $server_hostname the hostname of the CAS server
-     * @param string $server_port     the port the CAS server is running on
-     * @param string $server_uri      the URI the CAS server is responding on
-     * @param bool   $changeSessionID Allow phpCAS to change the session_id (Single
+     * @param string                  $server_version  the version of the CAS server
+     * @param string                  $server_hostname the hostname of the CAS server
+     * @param string                  $server_port     the port the CAS server is running on
+     * @param string                  $server_uri      the URI the CAS server is responding on
+     * @param bool                    $changeSessionID Allow phpCAS to change the session_id (Single
      * Sign Out/handleLogoutRequests is based on that change)
+     * @param SessionHandlerInterface $sessionHandler the session handler
      *
      * @return a newly created CAS_Client object
      * @note Only one of the phpCAS::client() and phpCAS::proxy functions should be
@@ -335,7 +336,7 @@ class phpCAS
      * and phpCAS::setDebug()).
      */
     public static function client($server_version, $server_hostname,
-        $server_port, $server_uri, $changeSessionID = true
+        $server_port, $server_uri, $changeSessionID = true, SessionHandlerInterface $sessionHandler = null
     ) {
         phpCAS :: traceBegin();
         if (is_object(self::$_PHPCAS_CLIENT)) {
@@ -355,7 +356,7 @@ class phpCAS
         try {
             self::$_PHPCAS_CLIENT = new CAS_Client(
                 $server_version, false, $server_hostname, $server_port, $server_uri,
-                $changeSessionID
+                $changeSessionID, $sessionHandler
             );
         } catch (Exception $e) {
             phpCAS :: error(get_class($e) . ': ' . $e->getMessage());
@@ -366,12 +367,13 @@ class phpCAS
     /**
      * phpCAS proxy initializer.
      *
-     * @param string $server_version  the version of the CAS server
-     * @param string $server_hostname the hostname of the CAS server
-     * @param string $server_port     the port the CAS server is running on
-     * @param string $server_uri      the URI the CAS server is responding on
-     * @param bool   $changeSessionID Allow phpCAS to change the session_id (Single
+     * @param string                  $server_version  the version of the CAS server
+     * @param string                  $server_hostname the hostname of the CAS server
+     * @param string                  $server_port     the port the CAS server is running on
+     * @param string                  $server_uri      the URI the CAS server is responding on
+     * @param bool                    $changeSessionID Allow phpCAS to change the session_id (Single
      * Sign Out/handleLogoutRequests is based on that change)
+     * @param SessionHandlerInterface $sessionHandler the session handler
      *
      * @return a newly created CAS_Client object
      * @note Only one of the phpCAS::client() and phpCAS::proxy functions should be
@@ -379,7 +381,7 @@ class phpCAS
      * and phpCAS::setDebug()).
      */
     public static function proxy($server_version, $server_hostname,
-        $server_port, $server_uri, $changeSessionID = true
+        $server_port, $server_uri, $changeSessionID = true, SessionHandlerInterface $sessionHandler = null
     ) {
         phpCAS :: traceBegin();
         if (is_object(self::$_PHPCAS_CLIENT)) {
@@ -399,7 +401,7 @@ class phpCAS
         try {
             self::$_PHPCAS_CLIENT = new CAS_Client(
                 $server_version, true, $server_hostname, $server_port, $server_uri,
-                $changeSessionID
+                $changeSessionID, $sessionHandler
             );
         } catch (Exception $e) {
             phpCAS :: error(get_class($e) . ': ' . $e->getMessage());

--- a/source/CAS/Session/PhpSession.php
+++ b/source/CAS/Session/PhpSession.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * PHP Version 5
+ *
+ * @file     CAS/Session/PhpSession.php
+ * @category Authentication
+ * @package  PhpCAS
+ * @author   Adam Franco <afranco@middlebury.edu>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
+ * @link     https://wiki.jasig.org/display/CASC/phpCAS
+ */
+
+/**
+ * Empty class used as a default implementation for phpCAS.
+ *
+ * Implements the standard PHP session handler without no alterations.
+ *
+ * @class    CAS_Session_PhpSession
+ * @category Authentication
+ * @package  PhpCAS
+ * @author   Adam Franco <afranco@middlebury.edu>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
+ * @link     https://wiki.jasig.org/display/CASC/phpCAS
+ */
+class CAS_Session_PhpSession extends SessionHandler implements SessionHandlerInterface
+{
+}

--- a/test/CAS/Tests/ServiceMailTest.php
+++ b/test/CAS/Tests/ServiceMailTest.php
@@ -80,11 +80,11 @@ class CAS_Tests_ServiceMailTest extends PHPUnit_Framework_TestCase
         // up the session manually so that we are in a state from which we can
         // attempt to fetch proxy tickets and make proxied requests.
 
-        $_SESSION['phpCAS']['user'] = 'jdoe';
-        $_SESSION['phpCAS']['pgt'] = 'PGT-clientapp-abc123';
-        $_SESSION['phpCAS']['proxies'] = array();
-        $_SESSION['phpCAS']['service_cookies'] = array();
-        $_SESSION['phpCAS']['attributes'] = array();
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['user'] = 'jdoe';
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['pgt'] = 'PGT-clientapp-abc123';
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['proxies'] = array();
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['service_cookies'] = array();
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['attributes'] = array();
 
         // Force Authentication to initialize the client.
         $this->object->forceAuthentication();

--- a/test/CAS/Tests/ServiceWebTest.php
+++ b/test/CAS/Tests/ServiceWebTest.php
@@ -79,11 +79,11 @@ class CAS_Tests_ServiceWebTest extends PHPUnit_Framework_TestCase
         // Bypass PGT storage since CAS_Client->callback() will exit. Just build
         // up the session manually so that we are in a state from which we can
         // attempt to fetch proxy tickets and make proxied requests.
-        $_SESSION['phpCAS']['user'] = 'jdoe';
-        $_SESSION['phpCAS']['pgt'] = 'PGT-clientapp-abc123';
-        $_SESSION['phpCAS']['proxies'] = array();
-        $_SESSION['phpCAS']['service_cookies'] = array();
-        $_SESSION['phpCAS']['attributes'] = array();
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['user'] = 'jdoe';
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['pgt'] = 'PGT-clientapp-abc123';
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['proxies'] = array();
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['service_cookies'] = array();
+        $_SESSION[CAS_Client::PHPCAS_SESSION_PREFIX]['attributes'] = array();
 
         // Force Authentication to initialize the client.
         $this->object->forceAuthentication();


### PR DESCRIPTION
Extracted out $_SESSION calls (mostly) to functions and added session handler setting to allow custom session interfaces.

The following mostly removes the direct calls to $_SESSION in the code into functions except for one place where it creates a CookieJar that requires a variable due to it being passed by reference.
It also adds a SessionHandler to the constructor for client so that a user can inject their own custom SessionHandler in cases where they don't want to use the default PHP session handler.
