### PR TITLE
Fix error in source/CAS/PGTStorage/Db.php

### DIFF
--- a/source/CAS/PGTStorage/Db.php
+++ b/source/CAS/PGTStorage/Db.php
@@ -253,7 +253,7 @@ class CAS_PGTStorage_Db extends CAS_PGTStorage_AbstractStorage
     protected function createTableSql()
     {
         return 'CREATE TABLE ' . $this->_getTable()
-            . ' (pgt_iou VARCHAR(255) NOT NULL PRIMARY KEY, pgt VARCHAR(255) NOT NULL)';
+            . ' (pgt_iou VARCHAR(200) NOT NULL PRIMARY KEY, pgt VARCHAR(255) NOT NULL)';
     }
 
     /**


### PR DESCRIPTION
Fix error in source/CAS/PGTStorage/Db.php,When my table is encoded as utf8mb4 - UTF-8 Unicode, varchar (255), will cause "SQLSTATE [42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes"