### PR TITLE
Remove fallback for __autoload (get ready for PHP 7.2)

### DIFF
--- a/source/CAS/Autoload.php
+++ b/source/CAS/Autoload.php
@@ -74,31 +74,16 @@ function CAS_autoload($class)
 }
 
 // set up __autoload
-if (function_exists('spl_autoload_register')) {
-    if (!(spl_autoload_functions())
-        || !in_array('CAS_autoload', spl_autoload_functions())
+if (!(spl_autoload_functions())
+    || !in_array('CAS_autoload', spl_autoload_functions())
+) {
+    spl_autoload_register('CAS_autoload');
+    if (function_exists('__autoload')
+        && !in_array('__autoload', spl_autoload_functions())
     ) {
-        spl_autoload_register('CAS_autoload');
-        if (function_exists('__autoload')
-            && !in_array('__autoload', spl_autoload_functions())
-        ) {
-            // __autoload() was being used, but now would be ignored, add
-            // it to the autoload stack
-            spl_autoload_register('__autoload');
-        }
-    }
-} elseif (!function_exists('__autoload')) {
-
-    /**
-     * Autoload a class
-     *
-     * @param string $class Class name
-     *
-     * @return bool
-     */
-    function __autoload($class)
-    {
-        return CAS_autoload($class);
+        // __autoload() was being used, but now would be ignored, add
+        // it to the autoload stack
+        spl_autoload_register('__autoload');
     }
 }
 


### PR DESCRIPTION
spl_autoload_register is present in PHP since 5.1.2, I can not find mentions of minimum supported PHP version for CAS but I'm sure it is more modern than that.

Defining function __autoload causes fatal error in PHP 7.2