### PR TITLE
Fix bad condition

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -2545,7 +2545,7 @@ class CAS_Client
         $this->ensureIsProxy();
 
     	// Argument validation
-    	if ((is_object($dsn_or_pdo) && !($dsn_or_pdo instanceof PDO)) || gettype($dsn_or_pdo) != 'string')
+    	if (!(is_object($dsn_or_pdo) && $dsn_or_pdo instanceof PDO) && gettype($dsn_or_pdo) != 'string')
 			throw new CAS_TypeMismatchException($dsn_or_pdo, '$dsn_or_pdo', 'string or PDO object');
     	if (gettype($username) != 'string')
         	throw new CAS_TypeMismatchException($username, '$username', 'string');


### PR DESCRIPTION
Inverting `string OR pdo object` condition should be `!string AND !pdo object`