### PR TITLE
Hash ticket strings to generate valid-length session-ids.

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1808,7 +1808,7 @@ class CAS_Client
             // If phpCAS is managing the session_id, destroy session thanks to
             // session_id.
             if ($this->getChangeSessionID()) {
-                $session_id = preg_replace('/[^a-zA-Z0-9\-]/', '', $ticket2logout);
+                $session_id = $this->_sessionIdForTicket($ticket2logout);
                 phpCAS::trace("Session id: ".$session_id);
 
                 // destroy a possible application session created before phpcas
@@ -3682,7 +3682,7 @@ class CAS_Client
                 phpCAS :: trace("Killing session: ". session_id());
                 session_destroy();
                 // set up a new session, of name based on the ticket
-                $session_id = preg_replace('/[^a-zA-Z0-9\-]/', '', $ticket);
+                $session_id = $this->_sessionIdForTicket($ticket);
                 phpCAS :: trace("Starting session: ". $session_id);
                 session_id($session_id);
                 session_start();
@@ -3701,6 +3701,23 @@ class CAS_Client
         phpCAS::traceEnd();
     }
 
+    /**
+     * Answer a valid session-id given a CAS ticket.
+     *
+     * The output must be deterministic to allow single-log-out when presented with
+     * the ticket to log-out.
+     *
+     *
+     * @param string $ticket name of the ticket
+     *
+     * @return string
+     */
+    private function _sessionIdForTicket($ticket)
+    {
+      // Hash the ticket to ensure that the value meets the PHP 7.1 requirement
+      // that session-ids have a length between 22 and 256 characters.
+      return hash('sha256', $ticket);
+    }
 
     // ########################################################################
     //  AUTHENTICATION ERROR HANDLING


### PR DESCRIPTION
By using a sha256 hash of the ticket, the session-id is guaranteed to be
64 bytes long no matter how short or long the ticket provided by the CAS
server is.

This fixes #248, fixes #244, and partially addresses the comments in #224 with the
exception of an extra salt or random-seed when generating the hash.