### PR TITLE
Hash ticket for session id with salt

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -1686,6 +1686,27 @@ class phpCAS
     }
 
     /**
+     * Set a salt/seed for the session-id hash to make it harder to guess.
+     *
+     * When $changeSessionID = true phpCAS will create a session-id that is derived
+     * from the service ticket. Doing so allows phpCAS to look-up and destroy the
+     * proper session on single-log-out requests. While the service tickets
+     * provided by the CAS server may include enough data to generate a strong
+     * hash, clients may provide an additional salt to ensure that session ids
+     * are not guessable if the session tickets do not have enough entropy.
+     *
+     * @param string $salt The salt to combine with the session ticket.
+     *
+     * @return void
+     */
+     public static function setSessionIdSalt($salt) {
+       phpCAS :: traceBegin();
+       phpCAS::_validateClientExists();
+       self::$_PHPCAS_CLIENT->setSessionIdSalt($salt);
+       phpCAS :: traceEnd();
+     }
+
+    /**
      * If you want your service to be proxied you have to enable it (default
      * disabled) and define an accepable list of proxies that are allowed to
      * proxy your service.

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3716,7 +3716,25 @@ class CAS_Client
     {
       // Hash the ticket to ensure that the value meets the PHP 7.1 requirement
       // that session-ids have a length between 22 and 256 characters.
-      return hash('sha256', $ticket);
+      return hash('sha256', $this->_sessionIdSalt . $ticket);
+    }
+
+    /**
+     * Set a salt/seed for the session-id hash to make it harder to guess.
+     *
+     * @var string $_sessionIdSalt
+     */
+    private $_sessionIdSalt = '';
+
+    /**
+     * Set a salt/seed for the session-id hash to make it harder to guess.
+     *
+     * @param string $salt
+     *
+     * @return void
+     */
+    public function setSessionIdSalt($salt) {
+      $this->_sessionIdSalt = (string)$salt;
     }
 
     // ########################################################################

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1808,7 +1808,7 @@ class CAS_Client
             // If phpCAS is managing the session_id, destroy session thanks to
             // session_id.
             if ($this->getChangeSessionID()) {
-                $session_id = preg_replace('/[^a-zA-Z0-9\-]/', '', $ticket2logout);
+                $session_id = $this->_sessionIdForTicket($ticket2logout);
                 phpCAS::trace("Session id: ".$session_id);
 
                 // destroy a possible application session created before phpcas
@@ -3682,7 +3682,7 @@ class CAS_Client
                 phpCAS :: trace("Killing session: ". session_id());
                 session_destroy();
                 // set up a new session, of name based on the ticket
-                $session_id = preg_replace('/[^a-zA-Z0-9\-]/', '', $ticket);
+                $session_id = $this->_sessionIdForTicket($ticket);
                 phpCAS :: trace("Starting session: ". $session_id);
                 session_id($session_id);
                 session_start();
@@ -3701,6 +3701,23 @@ class CAS_Client
         phpCAS::traceEnd();
     }
 
+    /**
+     * Answer a valid session-id given a CAS ticket.
+     *
+     * The output must be deterministic to allow single-log-out when presented with
+     * the ticket to log-out.
+     *
+     *
+     * @param string $ticket name of the ticket
+     *
+     * @return string
+     */
+    private function _sessionIdForTicket($ticket)
+    {
+      // Hash the ticket to ensure that the value meets the PHP 7.1 requirement
+      // that session-ids have a length between 22 and 256 characters.
+      return hash('sha256', $ticket);
+    }
 
     // ########################################################################
     //  AUTHENTICATION ERROR HANDLING


### PR DESCRIPTION
In addition to the fixes in PR #257, this PR includes a configurable session-id salt value as well as the API to set it. This should address the second part of #224.