### PR TITLE
More robust check for Windows OS in File.php

### DIFF
--- a/source/CAS/PGTStorage/File.php
+++ b/source/CAS/PGTStorage/File.php
@@ -122,7 +122,7 @@ class CAS_PGTStorage_File extends CAS_PGTStorage_AbstractStorage
             $path = CAS_PGT_STORAGE_FILE_DEFAULT_PATH;
         }
         // check that the path is an absolute path
-        if (getenv("OS")=="Windows_NT") {
+        if (getenv("OS")=="Windows_NT" || strtoupper(substr(PHP_OS,0,3)) == 'WIN') {
 
             if (!preg_match('`^[a-zA-Z]:`', $path)) {
                 phpCAS::error('an absolute path is needed for PGT storage to file');


### PR DESCRIPTION
A common pattern in PHP configurations is to have environment variables turned off. This means on line 125 getenv("OS") will fail and Windows will fail to be detected. Therefore I've added Windows detection using the PHP_OS constant as a fallback.