### PR TITLE
Fix "phpCAS" class capitalization in code

### DIFF
--- a/docs/Upgrading
+++ b/docs/Upgrading
@@ -2,10 +2,10 @@
 ### Upgrading 1.3.3 -> 1.3.4 ###
 ################################
 
-For security hardening purposes the verbose error messages to the web browsers 
-are now masked. If you want to have the verbose messages you need to use: 
+For security hardening purposes the verbose error messages to the web browsers
+are now masked. If you want to have the verbose messages you need to use:
 phpCAS::setVerbose(true);
-This will set the configuration to the old verbose mode that helps during 
+This will set the configuration to the old verbose mode that helps during
 development and debugging.
 
 
@@ -68,7 +68,7 @@ For quick testing or in certain production screnarios you might want to
 allow allow any other valid service to proxy your service. To do so, add
 the "Any" chain:
 
-      phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+      phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
 
 THIS SETTING IS HOWEVER NOT RECOMMENDED FOR PRODUCTION AND HAS SECURITY
  IMPLICATIONS: YOU ARE ALLOWING ANY SERVICE TO ACT ON BEHALF OF A USER

--- a/docs/examples/example_service.php
+++ b/docs/examples/example_service.php
@@ -69,11 +69,11 @@ phpCAS::allowProxyChain(
 // For quick testing or in certain production screnarios you might want to
 // allow allow any other valid service to proxy your service. To do so, add
 // the "Any" chain:
-// 		phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+// 		phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
 // THIS SETTING IS HOWEVER NOT RECOMMENDED FOR PRODUCTION AND HAS SECURITY
 // IMPLICATIONS: YOU ARE ALLOWING ANY SERVICE TO ACT ON BEHALF OF A USER
 // ON THIS SERVICE.
-//phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+//phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
 
 // force CAS authentication
 phpCAS::forceAuthentication();

--- a/docs/examples/example_service_POST.php
+++ b/docs/examples/example_service_POST.php
@@ -62,11 +62,11 @@ phpCAS::allowProxyChain(new CAS_ProxyChain(array($pgtUrlRegexp)));
 // For quick testing or in certain production screnarios you might want to
 // allow allow any other valid service to proxy your service. To do so, add
 // the "Any" chain:
-// 		phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+// 		phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
 // THIS SETTING IS HOWEVER NOT RECOMMENDED FOR PRODUCTION AND HAS SECURITY
 // IMPLICATIONS: YOU ARE ALLOWING ANY SERVICE TO ACT ON BEHALF OF A USER
 // ON THIS SERVICE.
-//phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+//phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
 
 // force CAS authentication
 phpCAS::forceAuthentication();

--- a/docs/examples/example_service_that_proxies.php
+++ b/docs/examples/example_service_that_proxies.php
@@ -62,11 +62,11 @@ phpCAS::allowProxyChain(new CAS_ProxyChain(array($pgtUrlRegexp)));
 // For quick testing or in certain production screnarios you might want to
 // allow allow any other valid service to proxy your service. To do so, add
 // the "Any" chain:
-// 		phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+// 		phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
 // THIS SETTING IS HOWEVER NOT RECOMMENDED FOR PRODUCTION AND HAS SECURITY
 // IMPLICATIONS: YOU ARE ALLOWING ANY SERVICE TO ACT ON BEHALF OF A USER
 // ON THIS SERVICE.
-//phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+//phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
 
 // force CAS authentication
 phpCAS::forceAuthentication();

--- a/source/CAS.php
+++ b/source/CAS.php
@@ -1732,7 +1732,7 @@ class phpCAS
      * For quick testing or in certain production screnarios you might want to
      * allow allow any other valid service to proxy your service. To do so, add
      * the "Any" chain:
-     *		phpcas::allowProxyChain(new CAS_ProxyChain_Any);
+     *		phpCAS::allowProxyChain(new CAS_ProxyChain_Any);
      * THIS SETTING IS HOWEVER NOT RECOMMENDED FOR PRODUCTION AND HAS SECURITY
      * IMPLICATIONS: YOU ARE ALLOWING ANY SERVICE TO ACT ON BEHALF OF A USER
      * ON THIS SERVICE.

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -131,7 +131,7 @@ class CAS_Client
         $lang = $this->getLangObj();
         $this->_htmlFilterOutput(
             empty($this->_output_footer)?
-            (phpcas::getVerbose())?
+            (phpCAS::getVerbose())?
                 '<hr><address>phpCAS __PHPCAS_VERSION__ '
                 .$lang->getUsingServer()
                 .' <a href="__SERVER_BASE_URL__">__SERVER_BASE_URL__</a> (CAS __CAS_VERSION__)</a></address></body></html>'


### PR DESCRIPTION
Searched through the source code and replaced "phpcas::" -> "phpCAS::". Fixes #273.