### PR TITLE
Fix continue statement within switch/case keeping original behavior

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3380,7 +3380,7 @@ class CAS_Client
                 case 'user':
                 case 'proxies':
                 case 'proxyGrantingTicket':
-                    continue;
+                    break;
                 default:
                     if (strlen(trim($attr_node->nodeValue))) {
                         phpCas :: trace(


### PR DESCRIPTION
continue statements within switch/case statements always have
behaved like break (ending the switch). Only exception is when
they are within a loop and we may want to use 'continue 2;'
instead (to jump to next iteration).

PHP7.3 has added a PHPWarning for all this switch/case/continue
uses (https://wiki.php.net/rfc/continue_on_switch_deprecation) so
this just changes is to the BC equivalent break. As far as there
isn't remaining code in the loop after the switch, it is 100%
the same than a continue 2.