### PR TITLE
add method to get list of supported protocols

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -69,6 +69,10 @@ define('PHPCAS_VERSION', '1.3.6+');
  */
 
 /**
+ * phpCAS supported protocols. accessible for the user by phpCAS::getSupportedProtocols().
+ */
+
+/**
  * CAS version 1.0
  */
 define("CAS_VERSION_1_0", '1.0');
@@ -714,6 +718,22 @@ class phpCAS
     public static function getVersion()
     {
         return PHPCAS_VERSION;
+    }
+
+    /**
+     * This method returns supported protocols.
+     *
+     * @return an array of all supported protocols. Use internal protocol name as array key.
+     */
+    public static function getSupportedProtocols()
+    {
+        $supportedProtocols = array();
+        $supportedProtocols[CAS_VERSION_1_0] = 'CAS 1.0';
+        $supportedProtocols[CAS_VERSION_2_0] = 'CAS 2.0';
+        $supportedProtocols[CAS_VERSION_3_0] = 'CAS 3.0';
+        $supportedProtocols[SAML_VERSION_1_1] = 'SAML 1.1';
+
+        return $supportedProtocols;
     }
 
     /** @} */

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -953,26 +953,21 @@ class CAS_Client
             );
         }
 
-        //check version
-        switch ($server_version) {
-        case CAS_VERSION_1_0:
-            if ( $this->isProxy() ) {
-                phpCAS::error(
-                    'CAS proxies are not supported in CAS '.$server_version
-                );
-            }
-            break;
-        case CAS_VERSION_2_0:
-        case CAS_VERSION_3_0:
-            break;
-        case SAML_VERSION_1_1:
-            break;
-        default:
+        // check version
+        $supportedProtocols = phpCAS::getSupportedProtocols();
+        if (isset($supportedProtocols[$server_version]) === false) {
             phpCAS::error(
                 'this version of CAS (`'.$server_version
                 .'\') is not supported by phpCAS '.phpCAS::getVersion()
             );
         }
+
+        if ($server_version === CAS_VERSION_1_0 && $this->isProxy()) {
+            phpCAS::error(
+                'CAS proxies are not supported in CAS '.$server_version
+            );
+        }
+
         $this->_server['version'] = $server_version;
 
         // check hostname


### PR DESCRIPTION
I didn't find a way to get list of all supported protocols by a version of phpCAS (eg: to build an selection HTML input on settings page for a third application).

With this method, developers can handle any new protocols without have to modify their own code.
