### PR TITLE
Fix phpDoc type hint for phpCAS::client()

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -329,7 +329,7 @@ class phpCAS
      *
      * @param string $server_version  the version of the CAS server
      * @param string $server_hostname the hostname of the CAS server
-     * @param string $server_port     the port the CAS server is running on
+     * @param int    $server_port     the port the CAS server is running on
      * @param string $server_uri      the URI the CAS server is responding on
      * @param bool   $changeSessionID Allow phpCAS to change the session_id (Single
      * Sign Out/handleLogoutRequests is based on that change)


### PR DESCRIPTION
This pull request updates the phpDoc type hint for `phpCAS::client()` to match `CAS_Client::__construct()`.

https://github.com/apereo/phpCAS/blob/89ce13044a629eb07c23e1bca0cb4926acf6ea00/source/CAS/Client.php#L888-L902