### PR TITLE
Build and upload PEAR packages to GitHub on releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,30 @@
 language: php
 php:
-  - "5.4"
-  - "5.5"
-  - "5.6"
+- '5.4'
+- '5.5'
+- '5.6'
+services:
+- docker
 script:
-  - cd test
-  - phpunit TestSuite.php
+- cd test
+- phpunit TestSuite.php
+matrix:
+  fast_finish: true
+  include:
+  - stage: GitHub Release
+    php: '7.2'
+    script:
+    - docker run --rm -it -v $PWD:/app centos:centos7 /app/utils/build.sh
+    deploy:
+      provider: releases
+      file_glob: true
+      file: utils/dist/CAS-*.tgz
+      skip_cleanup: true
+      api_key:
+        secure: SetupEncryptionKeyUsingTravisCLITool
+      on:
+        repo: apereo/phpCAS
+        tags: true
 sudo: false
+notifications:
+  email: false

--- a/utils/build.sh
+++ b/utils/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+yum -y update && yum -y install ant doxygen php-pear
+
+cd /app/utils \
+&& pear upgrade --force --alldeps \
+&& pear install --onlyreqdeps PEAR_PackageFileManager2-beta \
+&& ant dist -Ddoxygen.path=/usr/bin/doxygen -Dphp.path=/usr/bin/php


### PR DESCRIPTION
Travis builds a PEAR package using the same method as the [idp-testbed](https://github.com/UniconLabs/dockerized-idp-testbed/blob/master/php-cas/Dockerfile#L3-L11). When the commit is tagged, the resulting package is uploaded to GitHub.

To demo the behavior, I tagged a release in my fork as [1.3.6-demo](https://github.com/pcfens/phpCAS/releases). Travis will only upload the tarball if other tests pass since this runs as [another stage](https://travis-ci.org/pcfens/phpCAS/builds/473504241).

After merging, line 24 of the .travis.yml file will need to be updated by someone with permissions on the apereo/phpCAS repository. The easiest way is to install the travis Ruby Gem and to run [`travis setup releases -r apereo/phpCAS`](https://docs.travis-ci.com/user/deployment/releases#using-travis-ci-client-to-populate-initial-deployment-configuration). The command will append a new section to the .travis.yml file, but everything except for the secure line should be deleted, and that line should replace the placeholder in the PR.