### PR TITLE
Enable Tests on PHP 7.x on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ php:
 - 'nightly'
 services:
 - docker
+install:
+- composer install
 script:
 - cd test
 - phpunit TestSuite.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 php:
 - '5.4'
 - '5.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ php:
 - 'nightly'
 services:
 - docker
-install:
+script:
+# Composer is testing-only; vendor folder should not appear in releases
 - if [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then composer --no-interaction config platform.php 7.4.0; fi
 - composer install
-script:
 - cd test && ../vendor/bin/phpunit --verbose --stderr
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ php:
 - '5.4'
 - '5.5'
 - '5.6'
+- '7.0'
+- '7.1'
+- '7.2'
+- '7.3'
+- 'nightly'
 services:
 - docker
 script:
@@ -10,6 +15,8 @@ script:
 - phpunit TestSuite.php
 matrix:
   fast_finish: true
+  allow_failures:
+    - php: "nightly"
   include:
   - stage: GitHub Release
     php: '7.2'
@@ -25,6 +32,5 @@ matrix:
       on:
         repo: apereo/phpCAS
         tags: true
-sudo: false
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ php:
 services:
 - docker
 install:
+- if [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then composer --no-interaction config platform.php 7.4.0; fi
 - composer install
 script:
 - cd test
-- phpunit TestSuite.php
+- ../vendor/bin/phpunit TestSuite.php
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ install:
 - if [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then composer --no-interaction config platform.php 7.4.0; fi
 - composer install
 script:
-- cd test
-- ../vendor/bin/phpunit TestSuite.php
+- cd test && ../vendor/bin/phpunit --verbose --stderr
 matrix:
   fast_finish: true
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7.10"
+        "phpunit/phpunit": "<8"
     },
     "autoload": {
         "classmap": [

--- a/test/TestSuite.php
+++ b/test/TestSuite.php
@@ -28,23 +28,11 @@
  */
 
 ob_start();
-require_once dirname(__FILE__) . '/../source/CAS.php';
-
-if(!class_exists('PHPUnit_Framework_TestSuite')) {
-    /**
-     * phpunit 5-7 compatibility
-     */
-    class PHPUnit_Framework_TestSuite extends PHPUnit\Framework\TestSuite {
-
-    }
-
-    class PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase {
-
-    }
-}
+require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
  * Suite of all tests
+ * Legacy; phpunit.xml should be used instead
  *
  * @class    TestSuite
  * @category Authentication

--- a/test/TestSuite.php
+++ b/test/TestSuite.php
@@ -30,6 +30,19 @@
 ob_start();
 require_once dirname(__FILE__) . '/../source/CAS.php';
 
+if(!class_exists('PHPUnit_Framework_TestSuite')) {
+    /**
+     * phpunit 5-7 compatibility
+     */
+    class PHPUnit_Framework_TestSuite extends PHPUnit\Framework\TestSuite {
+
+    }
+
+    class PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase {
+
+    }
+}
+
 /**
  * Suite of all tests
  *
@@ -46,7 +59,7 @@ class TestSuite extends PHPUnit_Framework_TestSuite
     /**
      * Create a new testsuite
      *
-     * @return PhpcasTestSuite
+     * @return TestSuite
      */
     public static function suite()
     {

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * PHP Version 5
+ *
+ * @file     bootstrap.php
+ * @category Authentication
+ * @package  PhpCAS
+ * @author   Henry Pan <phpcas@phy25.com>
+ * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
+ * @link     https://wiki.jasig.org/display/CASC/phpCAS
+ */
+
+require_once dirname(__FILE__) . '/../source/CAS.php';
+
+if(!class_exists('PHPUnit_Framework_TestSuite')) {
+    /**
+     * phpunit 5-7 compatibility
+     */
+    class PHPUnit_Framework_TestSuite extends PHPUnit\Framework\TestSuite {
+
+    }
+
+    /**
+     * phpunit 5-6 compatibility
+     */
+    class PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase {
+
+    }
+}

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    bootstrap="bootstrap.php"
+    convertNoticesToExceptions="false"
+    colors="true"
+    stderr="true"
+    backupGlobals="true"
+    >
+
+    <testsuites>
+        <testsuite name="phpCAS Tests">
+            <directory suffix="Test.php">CAS/Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">../source/</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
This PR enables tests on PHP 7.x and nightly on Travis CI to improve unit tests.

Major changes:

- Force Travis CI platform to trusty to test PHP 5.4+
- Add `phpunit.xml` to bypass `TestSuite.php` (because of compatibility issue in PHPUnit 7 v.s. support to PHP 5.x)
- Add `bootstrap.php` for tests, including a compat layer for PHPUnit 5-7
- Change PHPUnit requirement in composer to `<8`, and use composer-installed PHPUnit to run tests in Travis CI
  - Composer will pick the most suitable version in regards to PHP dist - which is great
  - `composer install` will only happen in testing i.e. there is no `vendor` folder in releases