### PR TITLE
Allow running tests from the top level directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 # Composer is testing-only; vendor folder should not appear in releases
 - if [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then composer --no-interaction config platform.php 7.4.0; fi
 - composer install
-- cd test && ../vendor/bin/phpunit --verbose --stderr
+- ./vendor/bin/phpunit --verbose --stderr
 matrix:
   fast_finish: true
   allow_failures:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    bootstrap="../source/CAS.php"
+    bootstrap="source/CAS.php"
     convertNoticesToExceptions="false"
     colors="true"
     stderr="true"
@@ -9,13 +9,13 @@
 
     <testsuites>
         <testsuite name="phpCAS Tests">
-            <directory suffix="Test.php">CAS/Tests/</directory>
+            <directory>test/CAS/Tests/</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">../source/</directory>
+            <directory>source/</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/test/README.txt
+++ b/test/README.txt
@@ -8,13 +8,11 @@ These unit tests currently only cover a small portion of the operation of phpCAS
 **************************
 * Running tests
 **************************
-1. Install PHPUnit using instructions on this page:
-	http://pear.phpunit.de/
+1. Install PHPUnit using composer:
+	composer install
 
-2. cd to the phpcas/test/ directory.
-
-3. Run the following command:
-	phpunit
+2. Run the following command:
+	./vendor/bin/phpunit
 
 
 


### PR DESCRIPTION
This makes it simpler for contributors to run tests, and it better follows community wide conventions.

The test configuration now follows the PHPUnit recommendations at: https://phpunit.readthedocs.io/en/8.5/organizing-tests.html

The PHPUnit XML configuration has been moved to the top level directory. Relative paths have been adjusted to account for the new location. The unnecessary "suffix" attributes have been removed, they just repeat defaults.