### PR TITLE
Remove workaround for unsupported PHP 5.2

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -44,11 +44,6 @@ if (!isset($_SERVER['REQUEST_URI']) && isset($_SERVER['SCRIPT_NAME']) && isset($
     $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'] . '?' . $_SERVER['QUERY_STRING'];
 }
 
-// Add a E_USER_DEPRECATED for php versions <= 5.2
-if (!defined('E_USER_DEPRECATED')) {
-    define('E_USER_DEPRECATED', E_USER_NOTICE);
-}
-
 
 // ########################################################################
 //  CONSTANTS


### PR DESCRIPTION
The project requires PHP >= 5.4, so the workaround is unnecessary.