### PR TITLE
Add support for logging via a PSR-3 logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "psr/log": "^1.0.0"
     },
     "require-dev": {
+        "monolog/monolog": "^1.0.0",
         "phpunit/phpunit": ">=4.8.35 <8"
     },
     "autoload": {

--- a/test/CAS/Tests/LogTest.php
+++ b/test/CAS/Tests/LogTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+class CAS_Tests_LogTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $logPath;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->logPath = tempnam(sys_get_temp_dir(), 'phpCAS');
+        $this->logger = new Logger('name');
+        $handler = new StreamHandler($this->logPath);
+        $format = "%message%\n";
+        $formatter = new LineFormatter($format);
+        $handler->setFormatter($formatter);
+        $this->logger->pushHandler($handler);
+    }
+
+    public function tearDown()
+    {
+        unlink($this->logPath);
+        parent::tearDown();
+    }
+
+    public function testSetLogger()
+    {
+        phpCAS::setLogger($this->logger);
+        $client = new CAS_Client(
+            CAS_VERSION_2_0, // Server Version
+            false, // Proxy
+            'cas.example.edu', // Server Hostname
+            443, // Server port
+            '/cas/', // Server URI
+            false // Start Session
+        );
+        $contents = file_get_contents($this->logPath);
+        // C750 .START (2020-01-11 23:18:05) phpCAS-1.3.8+ ****************** [CAS.php:454]
+        // C750 .=> CAS_Client::__construct('2.0', false, 'cas.example.edu', 443, '/cas/', false) [LogTest.php:39]
+        // C750 .|    Session is not authenticated [Client.php:938]
+        // C750 .<= ''
+        // EOF
+        $lines = explode("\n", $contents);
+        $this->assertCount(5, $lines);
+        $this->assertContains('Session is not authenticated', $lines[2]);
+    }
+
+    public function testSetLoggerNull()
+    {
+        phpCAS::setLogger($this->logger);
+        phpCAS::setLogger(null);
+        $client = new CAS_Client(
+            CAS_VERSION_2_0, // Server Version
+            false, // Proxy
+            'cas.example.edu', // Server Hostname
+            443, // Server port
+            '/cas/', // Server URI
+            false // Start Session
+        );
+        $contents = file_get_contents($this->logPath);
+        // C750 .START (2020-01-11 23:18:05) phpCAS-1.3.8+ ****************** [CAS.php:454]
+        // EOF
+        $lines = explode("\n", $contents);
+        $this->assertCount(2, $lines);
+    }
+}


### PR DESCRIPTION
PSR-3 is a PHP standard for cross-library inter-operation and
compatibility. Details on the specifics of PSR-3 are at:

https://www.php-fig.org/psr/psr-3/

Uses the psr/log package to enforce the PSR-3 LoggerInterface.

https://packagist.org/packages/psr/log

The old phpCAS::setDebug() is deprecated in favor using a logger, but
will continue to work for backward compatibility. Users that wish to
continue logging to a flat file with the new interface can do so using a
PSR-3 logger such as Monolog's StreamHandler.