### PR TITLE
Prefer composer autoload over Autoload.php

### DIFF
--- a/CAS.php
+++ b/CAS.php
@@ -28,3 +28,5 @@
  */
 
 require_once __DIR__.'/source/CAS.php';
+
+trigger_error('Including CAS.php is deprecated. Install phpCAS using composer instead.', E_USER_DEPRECATED);

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
             "source/"
         ]
     },
+    "autoload-dev": {
+        "classmap": [
+            "test/"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.3.x-dev"

--- a/source/CAS/Autoload.php
+++ b/source/CAS/Autoload.php
@@ -31,7 +31,7 @@ function CAS_autoload($class)
     }
     // Setup the include path if it's not already set from a previous call
     if (empty($include_path)) {
-        $include_path = array(dirname(__DIR__), dirname(__DIR__) . '/../test/' );
+        $include_path = array(dirname(__DIR__));
     }
 
     // Declare local variable to store the expected full path to the file
@@ -73,10 +73,10 @@ function CAS_autoload($class)
     die ((string) $e);
 }
 
-// set up __autoload
-if (!(spl_autoload_functions())
-    || !in_array('CAS_autoload', spl_autoload_functions())
-) {
+// Set up autoload if not already configured by composer.
+if (!class_exists('CAS_Client'))
+{
+    trigger_error('phpCAS autoloader is deprecated. Install phpCAS using composer instead.', E_USER_DEPRECATED);
     spl_autoload_register('CAS_autoload');
     if (function_exists('__autoload')
         && !in_array('__autoload', spl_autoload_functions())


### PR DESCRIPTION
For details on composer autoload, see:

https://getcomposer.org/doc/04-schema.md#autoload

This helps move from a custom maintained autoload function to a standard
one built by composer. Composer's autoload function is widely used by
the larger PHP community and is well tested. To maintain backwards
compatibility, Autoload.php is still included, but emits a warning.

This helps moves the project towards adopting the community standard
PSR-4 autoloading:

https://www.php-fig.org/psr/psr-4/