### PR TITLE
Move the tests directory to PSR-4 autoloading

### DIFF
--- a/CAS.php
+++ b/CAS.php
@@ -28,3 +28,5 @@
  */
 
 require_once __DIR__.'/source/CAS.php';
+
+trigger_error('Including CAS.php is deprecated. Install phpCAS using composer instead.', E_USER_DEPRECATED);

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
         ]
     },
     "autoload-dev": {
-        "classmap": [
-            "test/"
-        ]
+        "psr-4": {
+            "PhpCas\\": "test/CAS/"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
             "source/"
         ]
     },
+    "autoload-dev": {
+        "classmap": [
+            "test/"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.3.x-dev"

--- a/source/CAS/Autoload.php
+++ b/source/CAS/Autoload.php
@@ -31,7 +31,7 @@ function CAS_autoload($class)
     }
     // Setup the include path if it's not already set from a previous call
     if (empty($include_path)) {
-        $include_path = array(dirname(__DIR__), dirname(__DIR__) . '/../test/' );
+        $include_path = array(dirname(__DIR__));
     }
 
     // Declare local variable to store the expected full path to the file
@@ -73,10 +73,10 @@ function CAS_autoload($class)
     die ((string) $e);
 }
 
-// set up __autoload
-if (!(spl_autoload_functions())
-    || !in_array('CAS_autoload', spl_autoload_functions())
-) {
+// Set up autoload if not already configured by composer.
+if (!class_exists('CAS_Client'))
+{
+    trigger_error('phpCAS autoloader is deprecated. Install phpCAS using composer instead.', E_USER_DEPRECATED);
     spl_autoload_register('CAS_autoload');
     if (function_exists('__autoload')
         && !in_array('__autoload', spl_autoload_functions())

--- a/test/CAS/TestHarness/BasicResponse.php
+++ b/test/CAS/TestHarness/BasicResponse.php
@@ -27,11 +27,15 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\TestHarness;
+
+use PhpCas\TestHarness\ResponseInterface;
+
 /**
  * The BasicResponse allows tests to dynamically create a response that can be used
  * in unit tests.
  *
- * @class    CAS_TestHarness_BasicResponse
+ * @class    BasicResponse
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
@@ -39,7 +43,7 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
-class CAS_TestHarness_BasicResponse implements CAS_TestHarness_ResponseInterface
+class BasicResponse implements ResponseInterface
 {
     protected $scheme = 'http';
     protected $host = null;
@@ -304,7 +308,7 @@ class CAS_TestHarness_BasicResponse implements CAS_TestHarness_ResponseInterface
     public function getResponseStatusCode()
     {
         if (!$this->sent) {
-            throw new CAS_OutOfSequenceException(
+            throw new \CAS_OutOfSequenceException(
                 'Request has not been sent yet. Cannot ' . __METHOD__
             );
         }
@@ -313,7 +317,7 @@ class CAS_TestHarness_BasicResponse implements CAS_TestHarness_ResponseInterface
             $this->responseHeaders[0], $matches
         )
         ) {
-            throw new CAS_Request_Exception(
+            throw new \CAS_Request_Exception(
                 "Bad response, no status code was found in the first line."
             );
         }

--- a/test/CAS/TestHarness/DummyMultiRequest.php
+++ b/test/CAS/TestHarness/DummyMultiRequest.php
@@ -27,12 +27,16 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\TestHarness;
+
+use PhpCas\TestHarness\DummyRequest;
+
 /**
  * This interface defines a class library for performing multiple web requests
  * in batches. Implementations of this interface may perform requests serially
  * or in parallel.
  *
- * @class    CAS_TestHarness_DummyMultiRequest
+ * @class    DummyMultiRequest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
@@ -40,8 +44,8 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
-class CAS_TestHarness_DummyMultiRequest implements
-CAS_Request_MultiRequestInterface
+class DummyMultiRequest implements
+\CAS_Request_MultiRequestInterface
 {
     private $_requests = array();
     private $_sent = false;
@@ -63,16 +67,16 @@ CAS_Request_MultiRequestInterface
      * @throws CAS_InvalidArgumentException If passed a Request of the wrong
      * implmentation.
      */
-    public function addRequest(CAS_Request_RequestInterface $request)
+    public function addRequest(\CAS_Request_RequestInterface $request)
     {
         if ($this->_sent) {
-            throw new CAS_OutOfSequenceException(
+            throw new \CAS_OutOfSequenceException(
                 'Request has already been sent cannot ' . __METHOD__
             );
         }
-        if (!$request instanceof CAS_TestHarness_DummyRequest) {
-            throw new CAS_InvalidArgumentException(
-                'As a CAS_TestHarness_DummyMultiRequest, I can only work with CAS_TestHarness_DummyRequest objects.'
+        if (!$request instanceof DummyRequest) {
+            throw new \CAS_InvalidArgumentException(
+                'As a DummyMultiRequest, I can only work with DummyRequest objects.'
             );
         }
 
@@ -94,12 +98,12 @@ CAS_Request_MultiRequestInterface
     public function send()
     {
         if ($this->_sent) {
-            throw new CAS_OutOfSequenceException(
+            throw new \CAS_OutOfSequenceException(
                 'Request has already been sent cannot send again.'
             );
         }
         if (!count($this->_requests)) {
-            throw new CAS_OutOfSequenceException(
+            throw new \CAS_OutOfSequenceException(
                 'At least one request must be added via addRequest() before the multi-request can be sent.'
             );
         }
@@ -119,7 +123,7 @@ CAS_Request_MultiRequestInterface
     public function getNumRequests()
     {
         if ($this->_sent) {
-            throw new CAS_OutOfSequenceException(
+            throw new \CAS_OutOfSequenceException(
                 'Request has already been sent cannot ' . __METHOD__
             );
         }

--- a/test/CAS/TestHarness/DummyRequest.php
+++ b/test/CAS/TestHarness/DummyRequest.php
@@ -27,30 +27,34 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\TestHarness;
+
+use PhpCas\TestHarness\ResponseInterface;
+
 /**
  * Provides support for performing dummy web-requests
  *
- * @class    CAS_TestHarness_DummyRequest
+ * @class    DummyRequest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_TestHarness_DummyRequest extends CAS_Request_AbstractRequest
-implements CAS_Request_RequestInterface
+class DummyRequest extends \CAS_Request_AbstractRequest
+implements \CAS_Request_RequestInterface
 {
     private static $_responses = array();
 
     /**
      * Configure a URL/Response that the test harness will respond to.
      *
-     * @param CAS_TestHarness_ResponseInterface $response response interface
+     * @param ResponseInterface $response response interface
      *
      * @return void
      */
     public static function addResponse(
-        CAS_TestHarness_ResponseInterface $response
+        ResponseInterface $response
     ) {
         self::$_responses[] = $response;
     }

--- a/test/CAS/TestHarness/ResponseInterface.php
+++ b/test/CAS/TestHarness/ResponseInterface.php
@@ -27,19 +27,21 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\TestHarness;
+
 /**
  * Implementations of this interface can validate a request and provide response
  * headers and body, allowing the spoofing of responses to web requests for testing
  * purposes.
  *
- * @class    CAS_TestHarness_ResponseInterface
+ * @class    ResponseInterface
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-interface CAS_TestHarness_ResponseInterface
+interface ResponseInterface
 {
 
     /**

--- a/test/CAS/Tests/AuthenticationTest.php
+++ b/test/CAS/Tests/AuthenticationTest.php
@@ -27,19 +27,23 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
+use PhpCas\TestHarness\BasicResponse;
+use PhpCas\TestHarness\DummyRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of service tickets.
  *
- * @class    CAS_Tests_AuthenticationTest
+ * @class    AuthenticationTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_AuthenticationTest extends TestCase
+class AuthenticationTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -57,7 +61,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
         //     	phpCAS::setDebug(dirname(__FILE__).'/../test.log');
         // 		error_reporting(E_ALL);
 
-        CAS_GracefullTerminationException::throwInsteadOfExiting();
+        \CAS_GracefullTerminationException::throwInsteadOfExiting();
 
         $_SERVER['SERVER_NAME'] = 'www.clientapp.com';
         $_SERVER['SERVER_PORT'] = '80';
@@ -68,7 +72,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
         $_SERVER['PHP_SELF'] = '/index.php';
         $_SESSION = array();
 
-        $this->object = new CAS_Client(
+        $this->object = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             true, // Proxy
             'cas.example.edu', // Server Hostname
@@ -77,7 +81,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
             false // Start Session
         );
 
-        $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
+        $this->object->setRequestImplementation('PhpCas\TestHarness\DummyRequest');
         $this->object->setCasServerCACert(__FILE__, true);
 
         /*********************************************************
@@ -85,7 +89,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
          *********************************************************/
 
         // Set up our response.
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/serviceValidate'
         );
         $response->setResponseHeaders(
@@ -107,7 +111,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
 </cas:serviceResponse>
 "
             );
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
     }
 
@@ -119,7 +123,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
      */
     protected function tearDown()
     {
-        CAS_TestHarness_DummyRequest::clearResponses();
+        DummyRequest::clearResponses();
         $_SESSION = array();
     }
 
@@ -135,7 +139,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
         ob_start();
         try {
             $this->object->forceAuthentication();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             ob_end_clean();
             throw $e;
         }

--- a/test/CAS/Tests/Cas20AttributesTest.php
+++ b/test/CAS/Tests/Cas20AttributesTest.php
@@ -27,19 +27,23 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
+use PhpCas\TestHarness\BasicResponse;
+use PhpCas\TestHarness\DummyRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of service tickets.
  *
- * @class    CAS_Tests_Cas20AttributeTest
+ * @class    Cas20AttributeTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_Cas20AttributesTest extends TestCase
+class Cas20AttributesTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -63,7 +67,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
         $_SERVER['PHP_SELF'] = '/index.php';
         $_SESSION = array();
 
-        $this->object = new CAS_Client(
+        $this->object = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             false, // Proxy
             'cas.example.edu', // Server Hostname
@@ -72,7 +76,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
             false // Start Session
         );
 
-        $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
+        $this->object->setRequestImplementation('PhpCas\TestHarness\DummyRequest');
         $this->object->setCasServerCACert(__FILE__, true);
         $this->object->setNoClearTicketsFromUrl();
         // 		phpCAS::setDebug(dirname(__FILE__).'/../test.log');
@@ -86,7 +90,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
      */
     protected function tearDown()
     {
-        CAS_TestHarness_DummyRequest::clearResponses();
+        DummyRequest::clearResponses();
     }
 
     /**
@@ -97,7 +101,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
     public function testRubycasAttributes()
     {
         // Set up our response.
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/serviceValidate'
         );
         $response->setResponseHeaders(
@@ -126,7 +130,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->isAuthenticated();
@@ -152,7 +156,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
     public function testJasigAttributes()
     {
         // Set up our response.
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/serviceValidate'
         );
         $response->setResponseHeaders(
@@ -183,7 +187,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->isAuthenticated();
@@ -208,7 +212,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
     public function testJasigAttributesInternational()
     {
         // Set up our response.
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/serviceValidate'
         );
         $response->setResponseHeaders(
@@ -234,7 +238,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->isAuthenticated();
@@ -268,7 +272,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
     public function testNameValueAttributes()
     {
         // Set up our response.
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/serviceValidate'
         );
         $response->setResponseHeaders(
@@ -297,7 +301,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->isAuthenticated();

--- a/test/CAS/Tests/CookieJarTest.php
+++ b/test/CAS/Tests/CookieJarTest.php
@@ -27,12 +27,14 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test harness for the cookie Jar to allow us to test protected methods.
  *
- * @class    CAS_Tests_CookieJarExposed
+ * @class    CookieJarExposed
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
@@ -40,7 +42,7 @@ use PHPUnit\Framework\TestCase;
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
-class CAS_Tests_CookieJarExposed extends CAS_CookieJar
+class CookieJarExposed extends \CAS_CookieJar
 {
     /**
      * Wrapper to call protected methods
@@ -65,14 +67,14 @@ class CAS_Tests_CookieJarExposed extends CAS_CookieJar
  * Test class for verifying the operation of cookie handling methods used in
  * serviceWeb() proxy calls.
  *
- * @class    CAS_Tests_CookieJarTest
+ * @class    CookieJarTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_CookieJarTest extends TestCase
+class CookieJarTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -88,7 +90,7 @@ class CAS_Tests_CookieJarTest extends TestCase
     protected function setUp()
     {
         $this->cookieArray = array();
-        $this->object = new CAS_Tests_CookieJarExposed($this->cookieArray);
+        $this->object = new CookieJarExposed($this->cookieArray);
 
         $this->serviceUrl_1 = 'http://service.example.com/lookup/?action=search&query=username';
         $this->responseHeaders_1 = array('HTTP/1.1 302 Found',
@@ -389,7 +391,7 @@ class CAS_Tests_CookieJarTest extends TestCase
     public function testPublicStoreCookies()
     {
         $array = array();
-        $cookieJar = new CAS_CookieJar($array);
+        $cookieJar = new \CAS_CookieJar($array);
         $this->assertEquals(0, count($array));
         $cookieJar->storeCookies($this->serviceUrl_1, $this->responseHeaders_1);
         $this->assertEquals(1, count($array));

--- a/test/CAS/Tests/LogTest.php
+++ b/test/CAS/Tests/LogTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace PhpCas\Tests;
+
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 
-class CAS_Tests_LogTest extends TestCase
+class LogTest extends TestCase
 {
     /**
      * @var string
@@ -37,8 +39,8 @@ class CAS_Tests_LogTest extends TestCase
 
     public function testSetLogger()
     {
-        phpCAS::setLogger($this->logger);
-        $client = new CAS_Client(
+        \phpCAS::setLogger($this->logger);
+        $client = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             false, // Proxy
             'cas.example.edu', // Server Hostname
@@ -59,9 +61,9 @@ class CAS_Tests_LogTest extends TestCase
 
     public function testSetLoggerNull()
     {
-        phpCAS::setLogger($this->logger);
-        phpCAS::setLogger(null);
-        $client = new CAS_Client(
+        \phpCAS::setLogger($this->logger);
+        \phpCAS::setLogger(null);
+        $client = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             false, // Proxy
             'cas.example.edu', // Server Hostname

--- a/test/CAS/Tests/MultiRequestTest.php
+++ b/test/CAS/Tests/MultiRequestTest.php
@@ -27,19 +27,24 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
+use PhpCas\TestHarness\BasicResponse;
+use PhpCas\TestHarness\DummyMultiRequest;
+use PhpCas\TestHarness\DummyRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of service tickets.
  *
- * @class    CAS_Tests_MultiRequestTest
+ * @class    MultiRequestTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_MultiRequestTest extends TestCase
+class MultiRequestTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -58,7 +63,7 @@ class CAS_Tests_MultiRequestTest extends TestCase
         /*********************************************************
          * Enumerate our responses
          *********************************************************/
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'http', 'www.jasig.org', '/some/path'
         );
         $response->ensureIsGet();
@@ -73,9 +78,9 @@ class CAS_Tests_MultiRequestTest extends TestCase
             )
         );
         $response->setResponseBody("I am Jasig");
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'http', 'www.example.org', '/some/other/path'
         );
         $response->ensureIsGet();
@@ -90,9 +95,9 @@ class CAS_Tests_MultiRequestTest extends TestCase
             )
         );
         $response->setResponseBody("I am Example");
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'http', 'www.educause.edu', '/path'
         );
         $response->ensureIsGet();
@@ -107,7 +112,7 @@ class CAS_Tests_MultiRequestTest extends TestCase
             )
         );
         $response->setResponseBody("I am Educause");
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
     }
 
@@ -119,7 +124,7 @@ class CAS_Tests_MultiRequestTest extends TestCase
      */
     protected function tearDown()
     {
-        CAS_TestHarness_DummyRequest::clearResponses();
+        DummyRequest::clearResponses();
     }
 
     /**
@@ -129,7 +134,7 @@ class CAS_Tests_MultiRequestTest extends TestCase
      */
     public function testSingle()
     {
-        $request = new CAS_TestHarness_DummyRequest();
+        $request = new DummyRequest();
         $request->setUrl('http://www.example.org/some/other/path');
         $this->assertTrue($request->send());
         $this->assertEquals("I am Example", $request->getResponseBody());
@@ -142,17 +147,17 @@ class CAS_Tests_MultiRequestTest extends TestCase
      */
     public function testMultiple()
     {
-        $multi = new CAS_TestHarness_DummyMultiRequest();
+        $multi = new DummyMultiRequest();
 
-        $request1 = new CAS_TestHarness_DummyRequest();
+        $request1 = new DummyRequest();
         $request1->setUrl('http://www.jasig.org/some/path');
         $multi->addRequest($request1);
 
-        $request2 = new CAS_TestHarness_DummyRequest();
+        $request2 = new DummyRequest();
         $request2->setUrl('http://www.example.org/some/other/path');
         $multi->addRequest($request2);
 
-        $request3 = new CAS_TestHarness_DummyRequest();
+        $request3 = new DummyRequest();
         $request3->setUrl('http://www.educause.edu/path');
         $multi->addRequest($request3);
 

--- a/test/CAS/Tests/ProxyChainsTest.php
+++ b/test/CAS/Tests/ProxyChainsTest.php
@@ -27,19 +27,21 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of the proxy-chains validation system
  *
- * @class    CAS_Tests_ProxyChainsTests
+ * @class    ProxyChainsTests
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_ProxyChainsTest extends TestCase
+class ProxyChainsTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -54,7 +56,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
      */
     protected function setUp()
     {
-        $this->object = new CAS_ProxyChain_AllowedList;
+        $this->object = new \CAS_ProxyChain_AllowedList;
         $this->list_size_0 = array();
         $this->list_size_1 = array('https://service1.example.com/rest',);
         $this->list_size_2 = array('https://service1.example.com/rest',
@@ -122,7 +124,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
      */
     public function testAny()
     {
-        $this->object->allowProxyChain(new CAS_ProxyChain_Any);
+        $this->object->allowProxyChain(new \CAS_ProxyChain_Any);
         $this->assertTrue(
             $this->object->isProxyListAllowed($this->list_size_0),
             'Should allow any proxies in front.'
@@ -154,7 +156,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testExactMatch2()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://service1.example.com/rest',
                     'http://service2.example.com/my/path',
                 )
@@ -191,7 +193,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testExactMatch2Failure()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://service1.example.com/rest',
                     'http://other.example.com/my/path',
                 )
@@ -228,7 +230,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testTrustedMatch2()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain_Trusted(
+            new \CAS_ProxyChain_Trusted(
                 array('https://service1.example.com/rest',
                     'http://service2.example.com/my/path',
                 )
@@ -264,7 +266,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testPrefixMatch3()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://service1.example.com/',
                     'http://service2.example.com/my',
                     'http://service3.example.com/',
@@ -301,7 +303,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testRegexMatch2()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('/^https?:\/\/service1\.example\.com\/.*/',
                     '/^http:\/\/service[0-9]\.example\.com\/[^\/]+\/path/',
                 )
@@ -338,7 +340,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testMixedRegexMatch3()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://service1.example.com/',
                     '/^http:\/\/service[0-9]\.example\.com\/[^\/]+\/path/',
                     'http://service3.example.com/',
@@ -361,7 +363,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testMixedRegexTrusted3()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain_Trusted(
+            new \CAS_ProxyChain_Trusted(
                 array('https://service1.example.com/',
                     '/^http:\/\/service[0-9]\.example\.com\/[^\/]+\/path/',
                     'http://service3.example.com/',
@@ -383,7 +385,7 @@ class CAS_Tests_ProxyChainsTest extends TestCase
     public function testRegexModifiers()
     {
         $this->object->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('/^https?:\/\/service1\.EXAMPLE\.com\/.*/i',
                     '/^http:\/\/serVice[0-9]\.example\.com\/[^\/]+\/path/ix',
                 )

--- a/test/CAS/Tests/ProxyTicketValidationTest.php
+++ b/test/CAS/Tests/ProxyTicketValidationTest.php
@@ -27,19 +27,23 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
+use PhpCas\TestHarness\BasicResponse;
+use PhpCas\TestHarness\DummyRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of service tickets.
  *
- * @class    CAS_Tests_ProxyTicketValidationTest
+ * @class    ProxyTicketValidationTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_ProxyTicketValidationTest extends TestCase
+class ProxyTicketValidationTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -65,7 +69,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
 
         // 		$_GET['ticket'] = 'ST-123456-asdfasdfasgww2323radf3';
 
-        $this->object = new CAS_Client(
+        $this->object = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             false, // Proxy
             'cas.example.edu', // Server Hostname
@@ -74,14 +78,14 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
             false // Start Session
         );
 
-        $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
+        $this->object->setRequestImplementation('PhpCas\TestHarness\DummyRequest');
         $this->object->setCasServerCACert(__FILE__, true);
 
         /*********************************************************
          * Enumerate our responses
          *********************************************************/
         // Valid ticket response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxyValidate'
         );
         $response->matchQueryParameters(
@@ -112,10 +116,10 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         // Invalid ticket response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxyValidate'
         );
         $response->matchQueryParameters(
@@ -140,7 +144,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
     }
 
     /**
@@ -151,7 +155,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
      */
     protected function tearDown()
     {
-        CAS_TestHarness_DummyRequest::clearResponses();
+        DummyRequest::clearResponses();
     }
 
     /**
@@ -163,7 +167,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()
-            ->allowProxyChain(new CAS_ProxyChain_Any());
+            ->allowProxyChain(new \CAS_ProxyChain_Any());
         $result = $this->object
             ->validateCAS20($url, $text_response, $tree_response);
         $this->assertTrue($result);
@@ -191,7 +195,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()
-            ->allowProxyChain(new CAS_ProxyChain_Any());
+            ->allowProxyChain(new \CAS_ProxyChain_Any());
         $result = $this->object
             ->validateCAS20($url, $text_response, $tree_response);
         $this->assertTrue($result);
@@ -218,7 +222,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
         ob_start();
         try {
             $this->object->validateCAS20($url, $text_response, $tree_response);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             ob_end_clean();
             throw $e;
         }
@@ -237,7 +241,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
         try {
             $result = $this->object
                 ->validateCAS20($url, $text_response, $tree_response);
-        } catch (CAS_AuthenticationException $e) {
+        } catch (\CAS_AuthenticationException $e) {
         }
         ob_end_clean();
         $this->assertEquals(
@@ -255,14 +259,14 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('http://firstproxy.com',
                     'https://anotherdomain.org/mysite/test2'
                 )
             )
         );
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://anotherdomain.php')
             )
         );
@@ -293,12 +297,12 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain_Trusted(
+            new \CAS_ProxyChain_Trusted(
                 array('http://firstproxy.com')
             )
         );
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://anotherdomain.php')
             )
         );
@@ -332,7 +336,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://anotherdomain.php')
             )
         );
@@ -357,14 +361,14 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://anotherdomain.org/mysite/test2',
                     'http://firstproxy.com'
                 )
             )
         );
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('https://anotherdomain.php')
             )
         );
@@ -408,10 +412,10 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(array('/badregexp/'))
+            new \CAS_ProxyChain(array('/badregexp/'))
         );
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('/http\:\/\/firstproxy\.com.*$/',
                     '/^https\:\/\/anotherdomain.org\/mysite\/test2$/'
                 )
@@ -433,7 +437,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('/^http:\/\/secondproxy\.com/', '/^https.*$/')
             )
         );
@@ -458,7 +462,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-123456-asdfasdfasgww2323radf3');
         $this->object->getAllowedProxyChains()->allowProxyChain(
-            new CAS_ProxyChain(
+            new \CAS_ProxyChain(
                 array('/^https\:\/\/anotherdomain.org\/mysite\/test2$/',
                     '/http\:\/\/firstproxy\.com.*$/'
                 )

--- a/test/CAS/Tests/ServiceMailTest.php
+++ b/test/CAS/Tests/ServiceMailTest.php
@@ -27,19 +27,23 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
+use PhpCas\TestHarness\BasicResponse;
+use PhpCas\TestHarness\DummyRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of service tickets.
  *
- * @class    CAS_Tests_ServiceMailTest
+ * @class    ServiceMailTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_ServiceMailTest extends TestCase
+class ServiceMailTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -66,7 +70,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
         $_SERVER['PHP_SELF'] = '/index.php';
         $_SESSION = array();
 
-        $this->object = new CAS_Client(
+        $this->object = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             true, // Proxy
             'cas.example.edu', // Server Hostname
@@ -75,7 +79,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
             false // Start Session
         );
 
-        $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
+        $this->object->setRequestImplementation('PhpCas\TestHarness\DummyRequest');
         $this->object->setCasServerCACert(__FILE__, true);
 
         // Bypass PGT storage since CAS_Client->callback() will exit. Just build
@@ -100,7 +104,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
          *********************************************************/
 
         // Proxy ticket Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxy'
         );
         $response->matchQueryParameters(
@@ -129,14 +133,14 @@ class CAS_Tests_ServiceMailTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         /*********************************************************
          * 2. Proxy Ticket Error
          *********************************************************/
 
         // Error Proxy ticket Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxy'
         );
         $response->matchQueryParameters(
@@ -166,7 +170,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
         );
 
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         /*********************************************************
          * Ensure that IMAP constants are defined even if the IMAP
@@ -192,7 +196,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
      */
     protected function tearDown()
     {
-        CAS_TestHarness_DummyRequest::clearResponses();
+        DummyRequest::clearResponses();
     }
 
     /**

--- a/test/CAS/Tests/ServiceTicketValidationTest.php
+++ b/test/CAS/Tests/ServiceTicketValidationTest.php
@@ -27,19 +27,23 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
+use PhpCas\TestHarness\BasicResponse;
+use PhpCas\TestHarness\DummyRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of service tickets.
  *
- * @class    CAS_Tests_ServiceTicketValidationTest
+ * @class    ServiceTicketValidationTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_ServiceTicketValidationTest extends TestCase
+class ServiceTicketValidationTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -65,7 +69,7 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
 
         // 		$_GET['ticket'] = 'ST-123456-asdfasdfasgww2323radf3';
 
-        $this->object = new CAS_Client(
+        $this->object = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             false, // Proxy
             'cas.example.edu', // Server Hostname
@@ -74,14 +78,14 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
             false // Start Session
         );
 
-        $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
+        $this->object->setRequestImplementation('PhpCas\TestHarness\DummyRequest');
         $this->object->setCasServerCACert(__FILE__, true);
 
         /*********************************************************
          * Enumerate our responses
          *********************************************************/
         // Valid ticket response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/serviceValidate'
         );
         $response->matchQueryParameters(
@@ -109,10 +113,10 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         // Invalid ticket response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
         	'https', 'cas.example.edu', '/cas/serviceValidate'
         );
         $response->matchQueryParameters(
@@ -137,7 +141,7 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
     }
 
     /**
@@ -148,7 +152,7 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
      */
     protected function tearDown()
     {
-        CAS_TestHarness_DummyRequest::clearResponses();
+        DummyRequest::clearResponses();
     }
 
     /**
@@ -189,7 +193,7 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
         ob_start();
         try {
             $this->object->validateCAS20($url, $text_response, $tree_response);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             ob_end_clean();
             throw $e;
         }

--- a/test/CAS/Tests/ServiceWebTest.php
+++ b/test/CAS/Tests/ServiceWebTest.php
@@ -27,19 +27,23 @@
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
 
+namespace PhpCas\Tests;
+
+use PhpCas\TestHarness\BasicResponse;
+use PhpCas\TestHarness\DummyRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for verifying the operation of service tickets.
  *
- * @class    CAS_Tests_ServiceWebTest
+ * @class    ServiceWebTest
  * @category Authentication
  * @package  PhpCAS
  * @author   Adam Franco <afranco@middlebury.edu>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  */
-class CAS_Tests_ServiceWebTest extends TestCase
+class ServiceWebTest extends TestCase
 {
     /**
      * @var CAS_Client
@@ -66,7 +70,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
         $_SERVER['PHP_SELF'] = '/index.php';
         $_SESSION = array();
 
-        $this->object = new CAS_Client(
+        $this->object = new \CAS_Client(
             CAS_VERSION_2_0, // Server Version
             true, // Proxy
             'cas.example.edu', // Server Hostname
@@ -75,7 +79,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
             false // Start Session
         );
 
-        $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
+        $this->object->setRequestImplementation('PhpCas\TestHarness\DummyRequest');
         $this->object->setCasServerCACert(__FILE__, true);
 
         // Bypass PGT storage since CAS_Client->callback() will exit. Just build
@@ -99,7 +103,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
          *********************************************************/
 
         // Proxy ticket Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxy'
         );
         $response->matchQueryParameters(
@@ -128,10 +132,10 @@ class CAS_Tests_ServiceWebTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         // Valid Service Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'http', 'www.service.com', '/my_webservice'
         );
         $response->matchQueryParameters(
@@ -149,14 +153,14 @@ class CAS_Tests_ServiceWebTest extends TestCase
             )
         );
         $response->setResponseBody("Hello from the service.");
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         /*********************************************************
          * 2. Proxy Ticket Error
          *********************************************************/
 
         // Error Proxy ticket Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxy'
         );
         $response->matchQueryParameters(
@@ -186,14 +190,14 @@ class CAS_Tests_ServiceWebTest extends TestCase
         );
 
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         /*********************************************************
          * 3. Server that doesn't respond/exist (sending failure)
          *********************************************************/
 
         // Proxy ticket Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxy'
         );
         $response->matchQueryParameters(
@@ -221,14 +225,14 @@ class CAS_Tests_ServiceWebTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         /*********************************************************
          * 4. Service With Error status.
          *********************************************************/
 
         // Proxy ticket Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxy'
         );
         $response->matchQueryParameters(
@@ -257,10 +261,10 @@ class CAS_Tests_ServiceWebTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         // Service Error Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'http', 'www.service.com', '/my_webservice_that_has_problems'
         );
         $response->matchQueryParameters(
@@ -279,14 +283,14 @@ class CAS_Tests_ServiceWebTest extends TestCase
             )
         );
         $response->setResponseBody("Problems have Occurred.");
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         /*********************************************************
          * 5. Valid Proxy ticket and POST service
          *********************************************************/
 
         // Proxy ticket Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'https', 'cas.example.edu', '/cas/proxy'
         );
         $response->matchQueryParameters(
@@ -315,10 +319,10 @@ class CAS_Tests_ServiceWebTest extends TestCase
 "
         );
         $response->ensureCaCertPathEquals(__FILE__);
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
         // Valid Service Response
-        $response = new CAS_TestHarness_BasicResponse(
+        $response = new BasicResponse(
             'http', 'www.service.com', '/post_webservice'
         );
         $response->matchQueryParameters(
@@ -348,7 +352,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
         $response->setResponseBody(
             "<result><string>Yay, it worked.</string></result>"
         );
-        CAS_TestHarness_DummyRequest::addResponse($response);
+        DummyRequest::addResponse($response);
 
     }
 
@@ -360,7 +364,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
      */
     protected function tearDown()
     {
-        CAS_TestHarness_DummyRequest::clearResponses();
+        DummyRequest::clearResponses();
     }
 
     /**


### PR DESCRIPTION
This is first step towards moving the package to a namespace and the composer PSR-4 autoloader. The "classmap" autoloader is no longer used for tests.
    
As the tests are not part of the public API, this is backwards compatible.
    
Uses the PhpCas namespace.
    
Refs #188. Closes #331.