### PR TITLE
Remove the reference to test class from source/ directory

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1955,7 +1955,7 @@ class CAS_Client
         if (gettype($validate_cn) != 'boolean') {
             throw new CAS_TypeMismatchException($validate_cn, '$validate_cn', 'boolean');
         }
-        if ( !file_exists($cert) && $this->_requestImplementation !== 'CAS_TestHarness_DummyRequest'){
+        if (!file_exists($cert)) {
             throw new CAS_InvalidArgumentException("Certificate file does not exist " . $this->_requestImplementation);
         }
         $this->_cas_server_ca_cert = $cert;

--- a/test/CAS/Tests/AuthenticationTest.php
+++ b/test/CAS/Tests/AuthenticationTest.php
@@ -78,7 +78,7 @@ class CAS_Tests_AuthenticationTest extends TestCase
         );
 
         $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
-        $this->object->setCasServerCACert('/path/to/ca_cert.crt', true);
+        $this->object->setCasServerCACert(__FILE__, true);
 
         /*********************************************************
          * Enumerate our responses

--- a/test/CAS/Tests/Cas20AttributesTest.php
+++ b/test/CAS/Tests/Cas20AttributesTest.php
@@ -73,7 +73,7 @@ class CAS_Tests_Cas20AttributesTest extends TestCase
         );
 
         $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
-        $this->object->setCasServerCACert('/path/to/ca_cert.crt', true);
+        $this->object->setCasServerCACert(__FILE__, true);
         $this->object->setNoClearTicketsFromUrl();
         // 		phpCAS::setDebug(dirname(__FILE__).'/../test.log');
     }

--- a/test/CAS/Tests/ProxyTicketValidationTest.php
+++ b/test/CAS/Tests/ProxyTicketValidationTest.php
@@ -75,7 +75,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
         );
 
         $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
-        $this->object->setCasServerCACert('/path/to/ca_cert.crt', true);
+        $this->object->setCasServerCACert(__FILE__, true);
 
         /*********************************************************
          * Enumerate our responses
@@ -111,7 +111,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         // Invalid ticket response
@@ -139,7 +139,7 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
     }
 

--- a/test/CAS/Tests/ServiceMailTest.php
+++ b/test/CAS/Tests/ServiceMailTest.php
@@ -76,7 +76,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
         );
 
         $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
-        $this->object->setCasServerCACert('/path/to/ca_cert.crt', true);
+        $this->object->setCasServerCACert(__FILE__, true);
 
         // Bypass PGT storage since CAS_Client->callback() will exit. Just build
         // up the session manually so that we are in a state from which we can
@@ -128,7 +128,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         /*********************************************************
@@ -165,7 +165,7 @@ class CAS_Tests_ServiceMailTest extends TestCase
 "
         );
 
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         /*********************************************************

--- a/test/CAS/Tests/ServiceTicketValidationTest.php
+++ b/test/CAS/Tests/ServiceTicketValidationTest.php
@@ -75,7 +75,7 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
         );
 
         $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
-        $this->object->setCasServerCACert('/path/to/ca_cert.crt', true);
+        $this->object->setCasServerCACert(__FILE__, true);
 
         /*********************************************************
          * Enumerate our responses
@@ -108,7 +108,7 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         // Invalid ticket response
@@ -136,7 +136,7 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
     }
 

--- a/test/CAS/Tests/ServiceWebTest.php
+++ b/test/CAS/Tests/ServiceWebTest.php
@@ -76,7 +76,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
         );
 
         $this->object->setRequestImplementation('CAS_TestHarness_DummyRequest');
-        $this->object->setCasServerCACert('/path/to/ca_cert.crt', true);
+        $this->object->setCasServerCACert(__FILE__, true);
 
         // Bypass PGT storage since CAS_Client->callback() will exit. Just build
         // up the session manually so that we are in a state from which we can
@@ -127,7 +127,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         // Valid Service Response
@@ -185,7 +185,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
 "
         );
 
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         /*********************************************************
@@ -220,7 +220,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         /*********************************************************
@@ -256,7 +256,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         // Service Error Response
@@ -314,7 +314,7 @@ class CAS_Tests_ServiceWebTest extends TestCase
 </cas:serviceResponse>
 "
         );
-        $response->ensureCaCertPathEquals('/path/to/ca_cert.crt');
+        $response->ensureCaCertPathEquals(__FILE__);
         CAS_TestHarness_DummyRequest::addResponse($response);
 
         // Valid Service Response


### PR DESCRIPTION
The code in source/ previously contained a reference to the test class
CAS_TestHarness_DummyRequest. Avoid this special case so the source/
directory doesn't have a dependency on the tests.