### PR TITLE
Fix "risky" tests to no longer be risky

### DIFF
--- a/test/CAS/Tests/AuthenticationTest.php
+++ b/test/CAS/Tests/AuthenticationTest.php
@@ -127,19 +127,18 @@ class CAS_Tests_AuthenticationTest extends TestCase
      * Test that the user is redirected to the CAS server
      *
      * @return void
+     *
+     * @expectedException CAS_GracefullTerminationException
      */
     public function testRedirect()
     {
+        ob_start();
         try {
-            ob_start();
             $this->object->forceAuthentication();
-            $this->assertTrue(
-                false, 'Should have thrown a CAS_GracefullTerminationException.'
-            );
-        } catch (CAS_GracefullTerminationException $e) {
+        } catch (Exception $e) {
             ob_end_clean();
-            // It would be great to test for the existance of headers here, but
-            // the don't get set properly due to output before the test.
+            throw $e;
         }
+        ob_end_clean();
     }
 }

--- a/test/CAS/Tests/ProxyTicketValidationTest.php
+++ b/test/CAS/Tests/ProxyTicketValidationTest.php
@@ -216,20 +216,13 @@ class CAS_Tests_ProxyTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-1856339-aA5Yuvrxzpv8Tau1cYQ7');
         ob_start();
-        $result = $this->object
-            ->validateCAS20($url, $text_response, $tree_response);
+        try {
+            $this->object->validateCAS20($url, $text_response, $tree_response);
+        } catch (Exception $e) {
+            ob_end_clean();
+            throw $e;
+        }
         ob_end_clean();
-        $this->assertTrue($result);
-        $this->assertEquals(
-            "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-    <cas:authenticationFailure code='INVALID_TICKET'>
-        Ticket ST-1856339-aA5Yuvrxzpv8Tau1cYQ7 not recognized
-    </cas:authenticationFailure>
-</cas:serviceResponse>
-",
-            $text_response
-        );
-        $this->assertInstanceOf('DOMElement', $tree_response);
     }
 
     /**

--- a/test/CAS/Tests/ServiceTicketValidationTest.php
+++ b/test/CAS/Tests/ServiceTicketValidationTest.php
@@ -187,20 +187,13 @@ class CAS_Tests_ServiceTicketValidationTest extends TestCase
     {
         $this->object->setTicket('ST-1856339-aA5Yuvrxzpv8Tau1cYQ7');
         ob_start();
-        $result = $this->object
-            ->validateCAS20($url, $text_response, $tree_response);
+        try {
+            $this->object->validateCAS20($url, $text_response, $tree_response);
+        } catch (Exception $e) {
+            ob_end_clean();
+            throw $e;
+        }
         ob_end_clean();
-        $this->assertTrue($result);
-        $this->assertEquals(
-            "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
-    <cas:authenticationFailure code='INVALID_TICKET'>
-        Ticket ST-1856339-aA5Yuvrxzpv8Tau1cYQ7 not recognized
-    </cas:authenticationFailure>
-</cas:serviceResponse>
-",
-            $text_response
-        );
-        $this->assertInstanceOf('DOMElement', $tree_response);
     }
 
 }


### PR DESCRIPTION
Previously, when running PHPUnit, the following output would occur:

    There were 3 risky tests:

    1) CAS_Tests_AuthenticationTest::testRedirect
    This test did not perform any assertions

    .../phpCAS/test/CAS/Tests/AuthenticationTest.php:131

    2) CAS_Tests_ProxyTicketValidationTest::testInvalidTicketFailure
    Test code or tested code did not (only) close its own output buffers

    3) CAS_Tests_ServiceTicketValidationTest::testInvalidTicketFailure
    Test code or tested code did not (only) close its own output buffers

To solve these, always run ob_end_clean() before the test ends.

As these tests throw exceptions, all code after the exception is not run
and therefore can be removed.