### PR TITLE
PhpCas namespace parsing of legacy autoload code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
             "PhpCas\\": "test/CAS/"
         }
     },
+    "scripts": {
+        "test": "phpunit"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.3.x-dev"

--- a/source/CAS/Autoload.php
+++ b/source/CAS/Autoload.php
@@ -26,18 +26,24 @@ function CAS_autoload($class)
     // Static to hold the Include Path to CAS
     static $include_path;
     // Check only for CAS classes
-    if (substr($class, 0, 4) !== 'CAS_') {
+    if (substr($class, 0, 4) !== 'CAS_' && substr($class, 0, 7) !== 'PhpCas\\') {
         return false;
     }
+
     // Setup the include path if it's not already set from a previous call
     if (empty($include_path)) {
         $include_path = array(dirname(__DIR__));
     }
 
     // Declare local variable to store the expected full path to the file
-
     foreach ($include_path as $path) {
-        $file_path = $path . '/' . str_replace('_', '/', $class) . '.php';
+        $class_path = str_replace('_', DIRECTORY_SEPARATOR, $class);
+        // PhpCas namespace mapping
+        if (substr($class_path, 0, 7) === 'PhpCas\\') {
+            $class_path = 'CAS' . DIRECTORY_SEPARATOR . substr($class_path, 7);
+        }
+
+        $file_path = $path . DIRECTORY_SEPARATOR . $class_path . '.php';
         $fp = @fopen($file_path, 'r', true);
         if ($fp) {
             fclose($fp);
@@ -54,6 +60,7 @@ function CAS_autoload($class)
             return true;
         }
     }
+
     $e = new Exception(
         'Class ' . $class . ' could not be loaded from ' .
         $file_path . ', file does not exist (Path="'
@@ -86,5 +93,3 @@ if (!class_exists('CAS_Client'))
         spl_autoload_register('__autoload');
     }
 }
-
-?>


### PR DESCRIPTION
- Add test script to composer.json (`composer test`)
- Prepare for PhpCas namespace parsing of legacy autoload code
  - Remove closing PHP tag
  - Map PhpCas namespace to CAS folder
  - Use `DIRECTORY_SEPARATOR` if possible