### PR TITLE
Add PHP 7.4 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 - '7.1'
 - '7.2'
 - '7.3'
+- '7.4'
 - 'nightly'
 services:
 - docker


### PR DESCRIPTION
PHP 7.4 was release on 2019-11-28.

https://www.php.net/releases/7_4_0.php