### PR TITLE
Accept callback with extended HTTP_ACCESS headers

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -2595,11 +2595,7 @@ class CAS_Client
             if (preg_match('/^[PT]GT-[\.\-\w]+$/', $pgtId)) {
                 phpCAS::trace('Storing PGT `'.$pgtId.'\' (id=`'.$pgtIou.'\')');
                 $this->_storePGT($pgtId, $pgtIou);
-                if (array_key_exists('HTTP_ACCEPT', $_SERVER) &&
-                    (   $_SERVER['HTTP_ACCEPT'] == 'application/xml' ||
-                        $_SERVER['HTTP_ACCEPT'] == 'text/xml'
-                    )
-                ) {
+                if (array_key_exists('HTTP_ACCEPT', $_SERVER) && $this->isXmlResponse()) {
                     echo '<?xml version="1.0" encoding="UTF-8"?>' . "\r\n";
                     echo '<proxySuccess xmlns="http://www.yale.edu/tp/cas" />';
                     phpCAS::traceExit("XML response sent");
@@ -2626,6 +2622,22 @@ class CAS_Client
         throw new CAS_GracefullTerminationException();
     }
 
+    /**
+     * Check if application/xml or text/xml is pressent in HTTP_ACCEPT header values
+     * when return value is complex and contains attached q parameters.
+     * Example:  HTTP_ACCEPT = text/html,application/xhtml+xml,application/xml;q=0.9
+     * @return bool
+     */
+    private function isXmlResponse()
+    {
+        if (str_replace('application/xml', '', $_SERVER['HTTP_ACCEPT']) != 'application/xml') {
+            return true;
+        } elseif (str_replace('text/xml', '', $_SERVER['HTTP_ACCEPT']) != 'text/xml') {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     /** @} */
 

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -2595,7 +2595,7 @@ class CAS_Client
             if (preg_match('/^[PT]GT-[\.\-\w]+$/', $pgtId)) {
                 phpCAS::trace('Storing PGT `'.$pgtId.'\' (id=`'.$pgtIou.'\')');
                 $this->_storePGT($pgtId, $pgtIou);
-                if (array_key_exists('HTTP_ACCEPT', $_SERVER) && $this->isXmlResponse()) {
+                if ($this->isXmlResponse()) {
                     echo '<?xml version="1.0" encoding="UTF-8"?>' . "\r\n";
                     echo '<proxySuccess xmlns="http://www.yale.edu/tp/cas" />';
                     phpCAS::traceExit("XML response sent");
@@ -2630,9 +2630,12 @@ class CAS_Client
      */
     private function isXmlResponse()
     {
-        if (str_replace('application/xml', '', $_SERVER['HTTP_ACCEPT']) != 'application/xml') {
+        if (!array_key_exists('HTTP_ACCEPT', $_SERVER)) {
+            return false;
+        }
+        if (str_replace('application/xml', '', $_SERVER['HTTP_ACCEPT']) != $_SERVER['HTTP_ACCEPT']) {
             return true;
-        } elseif (str_replace('text/xml', '', $_SERVER['HTTP_ACCEPT']) != 'text/xml') {
+        } elseif (str_replace('text/xml', '', $_SERVER['HTTP_ACCEPT']) != $_SERVER['HTTP_ACCEPT']) {
             return true;
         } else {
             return false;

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -2633,13 +2633,11 @@ class CAS_Client
         if (!array_key_exists('HTTP_ACCEPT', $_SERVER)) {
             return false;
         }
-        if (str_replace('application/xml', '', $_SERVER['HTTP_ACCEPT']) != $_SERVER['HTTP_ACCEPT']) {
-            return true;
-        } elseif (str_replace('text/xml', '', $_SERVER['HTTP_ACCEPT']) != $_SERVER['HTTP_ACCEPT']) {
-            return true;
-        } else {
+        if (strpos('application/xml', $_SERVER['HTTP_ACCEPT']) === false and strpos('text/xml', $_SERVER['HTTP_ACCEPT']) === false) {
             return false;
         }
+        
+        return true;    
     }
 
     /** @} */


### PR DESCRIPTION
Fixes #341 
If the HTTP_ACCESS is complex like " text/html,application/xhtml+xml,application/xml;q=0.9" and not just "pplication/xml" or "text/xml" the callback will fail as error.