### PR TITLE
Added flag to ignore client port number in _getClientURL()

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -30,6 +30,7 @@
  * @author   Brett Bieber <brett.bieber@gmail.com>
  * @author   Joachim Fritschi <jfritschi@freenet.de>
  * @author   Adam Franco <afranco@middlebury.edu>
+ * @author   Davis Carlson <daviscarlson@uvic.ca>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  * @ingroup public
@@ -1636,6 +1637,22 @@ class phpCAS
     {
         phpCAS::_validateProxyExists();
         return (self::$_PHPCAS_CLIENT->getURL());
+    }
+
+    /**
+     * Tells phpCAS to ignore any potential port forwarding based on
+     * $_SERVER variables and not append any port number to the client URL
+     *
+     * @return void
+     */
+    public static function setIgnoreClientPort() {
+        phpCAS::traceBegin();
+        phpCAS::_validateClientExists();
+
+        phpCAS :: trace('You have configured phpCAS to not append any port number to the client url. This may cause an issue on servers with port forwarding.');
+        self::$_PHPCAS_CLIENT->setIgnoreClientPort();
+
+        phpCAS::traceEnd();
     }
 
     /**

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -45,6 +45,7 @@
  * @author   Joachim Fritschi <jfritschi@freenet.de>
  * @author   Adam Franco <afranco@middlebury.edu>
  * @author   Tobias Schiebeck <tobias.schiebeck@manchester.ac.uk>
+ * @author   Davis Carlson <daviscarlson@uvic.ca>
  * @license  http://www.apache.org/licenses/LICENSE-2.0  Apache License 2.0
  * @link     https://wiki.jasig.org/display/CASC/phpCAS
  *
@@ -3885,6 +3886,24 @@ class CAS_Client
     */
     private $_url = '';
 
+    /**
+     * if this is true, _getClientUrl() will not append the server port to
+     * the client URL, regardless of the $_SERVER headers set
+     *
+     * @hideinitializer
+     */
+    private $_ignore_client_port = false;
+
+    /**
+     * Sets $_ignore_client_port to true, ignoring any sort of port forwarding
+     * when generating client URL
+     *
+     * @return void
+     */
+    public function setIgnoreClientPort()
+    {
+        $this->_ignore_client_port = true;
+    }
 
     /**
      * This method sets the URL of the current request
@@ -3976,7 +3995,7 @@ class CAS_Client
                 $server_url = $_SERVER['SERVER_NAME'];
             }
         }
-        if (!strpos($server_url, ':')) {
+        if (!strpos($server_url, ':') && $this->_ignore_client_port === false) {
             if (empty($_SERVER['HTTP_X_FORWARDED_PORT'])) {
                 $server_port = $_SERVER['SERVER_PORT'];
             } else {


### PR DESCRIPTION
At my institution, we often have services sitting behind F5 LBs. When clients are redirected to CAS, _getClientURL() will append a ":80" to the callback URL since that is what appears in $_SERVER['SERVER_PORT']. This is due to the host and the LBs communicating over port 80, while the clients connect to the LBs via HTTPS. 

Since our CAS application list does not match a URL with a port, we have to comment-out this code in production applications.

This PR adds a flag that can be set to bypass the code that would append the port number to the client URL.