### PR TITLE
Support SameSite cookies attribute

### DIFF
--- a/source/CAS/CookieJar.php
+++ b/source/CAS/CookieJar.php
@@ -231,6 +231,7 @@ class CAS_CookieJar
             case 'commenturl':
             case 'discard':
             case 'httponly':
+            case 'samesite':
                 $cookie[$attributeNameLC] = $attributeValue;
                 break;
             default:


### PR DESCRIPTION
`CAS_CookieJar::parseCookieHeader` fails when cookie header contains a `SameSite` attribute.

Current:
`"set-cookie: foo=bar; SameSite=none;"` is parsed as `['name' => 'SameSite', 'value' => 'none']`

Expected:
 `['name' => 'foo', 'value' => 'bar', 'samesite' => 'none']`