### PR TITLE
Drop support for outdated PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 os: linux
 dist: xenial 
 php:
-- '7.0'
 - '7.1'
 - '7.2'
 - '7.3'

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
 		}
 	],
 	"require" : {
-		"php" : ">=7.0.0",
+		"php" : ">=7.1.0",
 		"ext-curl" : "*",
 		"psr/log" : "^1.0.0"
 	},
 	"require-dev" : {
 		"monolog/monolog" : "^1.0.0",
-		"phpunit/phpunit" : ">=4.8.35 <8"
+		"phpunit/phpunit" : ">=7.5 <8"
 	},
 	"autoload" : {
 		"classmap" : [


### PR DESCRIPTION
https://www.php.net/supported-versions.php

Support for PHP 7.1 and 7.2 remains on a best-effort basis to
accommodate users who haven’t upgraded yet.