### PR TITLE
Unpin PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require-dev" : {
 		"monolog/monolog" : "^1.0.0",
-		"phpunit/phpunit" : ">=7.5 <8"
+		"phpunit/phpunit" : ">=7.5"
 	},
 	"autoload" : {
 		"classmap" : [


### PR DESCRIPTION
Use the GitHub actions to specify the PHPUnit version for unsupported
PHP releases. The master branch can use the latest version of PHPUnit.