### PR TITLE
Use curl_setopt_array instead of loop in CurlRequest

### DIFF
--- a/source/CAS/Request/CurlRequest.php
+++ b/source/CAS/Request/CurlRequest.php
@@ -106,9 +106,7 @@ implements CAS_Request_RequestInterface
         *********************************************************/
         $ch = curl_init($this->url);
 
-        foreach ($this->_curlOptions as $key => $value) {
-            curl_setopt($ch, $key, $value);
-        }
+        curl_setopt_array($ch, $this->_curlOptions);
 
         /*********************************************************
          * Set SSL configuration


### PR DESCRIPTION
Mistake from 6f819097b5364930ce68a3e9a16f6a557329bb04 where the wrong
branch of the if was dropped.

Thanks @adaugherity for the report!