### PR TITLE
Removed unused `DEFAULT_ERROR` constant

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -136,11 +136,6 @@ define("SAML_SOAP_ENV_CLOSE", '</SOAP-ENV:Envelope>');
  */
 define("SAML_ATTRIBUTES", 'SAMLATTRIBS');
 
-/**
- * SAML Attributes
- */
-define("DEFAULT_ERROR", 'Internal script failure');
-
 /** @} */
 /**
  * @addtogroup publicPGTStorage


### PR DESCRIPTION
As stated by @lewart in the #393 `DEFAULT_ERROR` constant is no longer used.