### PR TITLE
Allow new versions of `psr/log`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require" : {
 		"php" : ">=7.1.0",
 		"ext-curl" : "*",
-		"psr/log" : "^1.0.0"
+		"psr/log" : "^1.0 || ^2.0 || ^3.0"
 	},
 	"require-dev" : {
 		"monolog/monolog" : "^1.0.0",


### PR DESCRIPTION
This seems to work fine with all available versions of the interface and other libraries (for example, Laravel), are using newer versions, so this change is needed to keep using the library.