### PR TITLE
Fix client when getting ticket and it's null

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -1057,7 +1057,7 @@ class CAS_Client
         } else {
             //normal mode: get ticket and remove it from CGI parameters for
             // developers
-            $ticket = (isset($_GET['ticket']) ? $_GET['ticket'] : null);
+            $ticket = (isset($_GET['ticket']) ? $_GET['ticket'] : '');
             if (preg_match('/^[SP]T-/', $ticket) ) {
                 phpCAS::trace('Ticket \''.$ticket.'\' found');
                 $this->setTicket($ticket);


### PR DESCRIPTION
Fix apply to solve an issue during call to preg_match, this method cannot be receive second parameter as null