### PR TITLE
Set User Agent

### DIFF
--- a/source/CAS/Request/CurlRequest.php
+++ b/source/CAS/Request/CurlRequest.php
@@ -163,7 +163,7 @@ implements CAS_Request_RequestInterface
         /*********************************************************
          * Set User Agent
          *********************************************************/
-        curl_setopt($ch, CURLOPT_USERAGENT, 'phpCAS');
+        curl_setopt($ch, CURLOPT_USERAGENT, 'phpCAS/' . phpCAS::getVersion());
 
         return $ch;
     }

--- a/source/CAS/Request/CurlRequest.php
+++ b/source/CAS/Request/CurlRequest.php
@@ -160,6 +160,11 @@ implements CAS_Request_RequestInterface
             curl_setopt($ch, CURLOPT_POSTFIELDS, $this->postBody);
         }
 
+        /*********************************************************
+         * Set User Agent
+         *********************************************************/
+        curl_setopt($ch, CURLOPT_USERAGENT, 'phpCAS');
+
         return $ch;
     }
 


### PR DESCRIPTION
Application firewalls tend to block HTTP requests without any User Agent set. I could change this a you would prefer, but the User Agent must be set.