### PR TITLE
Autoload source/CAS.php file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
 		"phpstan/phpstan" : "^1.5"
 	},
 	"autoload" : {
+		"files": ["source/CAS.php"],
 		"classmap" : [
 			"source/"
 		]
 	},
 	"autoload-dev" : {
-		"files": ["source/CAS.php"],
 		"psr-4" : {
 			"PhpCas\\" : "test/CAS/"
 		}


### PR DESCRIPTION
The `source/CAS.php` is not autoloaded.
We used to `require 'CAS.php';` but we get this :

> Including CAS.php is deprecated. Install phpCAS using composer instead.