### PR TITLE
Initialize session storage array only when populated

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -973,11 +973,6 @@ class CAS_Client
                 session_start();
                 phpCAS :: trace("Starting a new session " . session_id());
             }
-            // init phpCAS session array
-            if (!isset($_SESSION[static::PHPCAS_SESSION_PREFIX])
-                || !is_array($_SESSION[static::PHPCAS_SESSION_PREFIX])) {
-                $_SESSION[static::PHPCAS_SESSION_PREFIX] = array();
-            }
         }
 
         // Only for debug purposes
@@ -1198,7 +1193,19 @@ class CAS_Client
     {
         $this->validateSession($key);
 
+        $this->ensureSessionArray();
         $_SESSION[static::PHPCAS_SESSION_PREFIX][$key] = $value;
+    }
+
+    /**
+     * Ensure that the session array is initialized before writing to it.
+     */
+    protected function ensureSessionArray() {
+      // init phpCAS session array
+      if (!isset($_SESSION[static::PHPCAS_SESSION_PREFIX])
+          || !is_array($_SESSION[static::PHPCAS_SESSION_PREFIX])) {
+          $_SESSION[static::PHPCAS_SESSION_PREFIX] = array();
+      }
     }
 
     /**


### PR DESCRIPTION
Fix #429 by only initializing the session-storage array when values are populated.

Note that the `$_SESSION` array will only stay empty when `phpCAS::client()` is used. `phpCAS::proxy()` will still trigger the creation of `$_SESSION['phpcas']['service_cookies'] as that array currently needs to be passed as a refrence to the `CAS_CookieJar`'s constructor.