### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
             phpunit: '9'
           - php: '8.2'
             phpunit: '9'
+          - php: '8.3'
+            phpunit: '9'
+          - php: '8.4'
+            phpunit: '9'
     steps:
       - uses: actions/checkout@v2
       - uses: php-actions/composer@v6

--- a/source/CAS.php
+++ b/source/CAS.php
@@ -338,7 +338,7 @@ class phpCAS
      * @param bool                     $changeSessionID Allow phpCAS to change the session_id
      *                                                  (Single Sign Out/handleLogoutRequests
      *                                                  is based on that change)
-     * @param \SessionHandlerInterface $sessionHandler  the session handler
+     * @param \SessionHandlerInterface|null $sessionHandler  the session handler
      *
      * @return void a newly created CAS_Client object
      * @note Only one of the phpCAS::client() and phpCAS::proxy functions should be
@@ -347,7 +347,7 @@ class phpCAS
      */
     public static function client($server_version, $server_hostname,
         $server_port, $server_uri, $service_base_url,
-        $changeSessionID = true, \SessionHandlerInterface $sessionHandler = null
+        $changeSessionID = true, ?\SessionHandlerInterface $sessionHandler = null
     ) {
         phpCAS :: traceBegin();
         if (is_object(self::$_PHPCAS_CLIENT)) {
@@ -393,7 +393,7 @@ class phpCAS
      * @param bool                     $changeSessionID Allow phpCAS to change the session_id
      *                                                  (Single Sign Out/handleLogoutRequests
      *                                                  is based on that change)
-     * @param \SessionHandlerInterface $sessionHandler  the session handler
+     * @param \SessionHandlerInterface|null $sessionHandler  the session handler
      *
      * @return void a newly created CAS_Client object
      * @note Only one of the phpCAS::client() and phpCAS::proxy functions should be
@@ -402,7 +402,7 @@ class phpCAS
      */
     public static function proxy($server_version, $server_hostname,
         $server_port, $server_uri, $service_base_url,
-        $changeSessionID = true, \SessionHandlerInterface $sessionHandler = null
+        $changeSessionID = true, ?\SessionHandlerInterface $sessionHandler = null
     ) {
         phpCAS :: traceBegin();
         if (is_object(self::$_PHPCAS_CLIENT)) {

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -926,7 +926,7 @@ class CAS_Client
      *                                                  CAS_ServiceBaseUrl_Interface for custom
      *                                                  behavior. Added in 1.6.0. Similar to
      *                                                  serverName config in other CAS clients.
-     * @param \SessionHandlerInterface $sessionHandler  the session handler
+     * @param \SessionHandlerInterface|null $sessionHandler  the session handler
      *
      * @return self a newly created CAS_Client object
      */
@@ -938,7 +938,7 @@ class CAS_Client
         $server_uri,
         $service_base_url,
         $changeSessionID = true,
-        \SessionHandlerInterface $sessionHandler = null
+        ?\SessionHandlerInterface $sessionHandler = null
     ) {
         // Argument validation
         if (gettype($server_version) != 'string')


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated