### PR TITLE
Fix 'occured' -> 'occurred' in AuthenticationException and Client PHPDoc

### DIFF
--- a/source/CAS/AuthenticationException.php
+++ b/source/CAS/AuthenticationException.php
@@ -55,7 +55,7 @@ implements CAS_Exception
      * authenticated.
      *
      * @param CAS_Client $client       phpcas client
-     * @param string     $failure      the failure that occured
+     * @param string     $failure      the failure that occurred
      * @param string     $cas_url      the URL the CAS server was asked for
      * @param bool       $no_response  the response from the CAS server (other
      * parameters are ignored if TRUE)

--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -4163,7 +4163,7 @@ class CAS_Client
     * This method is used to print the HTML output when the user was not
     * authenticated.
     *
-    * @param string $failure      the failure that occured
+    * @param string $failure      the failure that occurred
     * @param string $cas_url      the URL the CAS server was asked for
     * @param bool   $no_response  the response from the CAS server (other
     * parameters are ignored if true)


### PR DESCRIPTION
Fix 2 PHPDoc typos:

- `source/CAS/AuthenticationException.php` line 58
- `source/CAS/Client.php` line 4166

Both describe `$failure` param docs. Comment-only change.